### PR TITLE
Refactor `conda_lockfiles.cli`

### DIFF
--- a/conda_lockfiles/cli/__init__.py
+++ b/conda_lockfiles/cli/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from .main_create import configure_parser as configure_parser_create
+
+    subparsers = parser.add_subparsers(
+        title="subcommand",
+        description="The following subcommands are available.",
+        dest="cmd",
+        required=True,
+    )
+
+    configure_parser_create(subparsers.add_parser("create"))
+
+
+def execute(args: argparse.Namespace) -> int:
+    return 0

--- a/conda_lockfiles/cli/main_create.py
+++ b/conda_lockfiles/cli/main_create.py
@@ -1,5 +1,5 @@
 """
-conda lockfiles subcommand for CLI
+conda lockfiles create subcommand for CLI
 """
 
 from __future__ import annotations
@@ -10,17 +10,17 @@ if TYPE_CHECKING:
     import argparse
 
 
-def configure_parser(parser: argparse.ArgumentParser):
+def configure_parser(parser: argparse.ArgumentParser) -> None:
     from conda.base.context import context
-    from conda.cli.conda_argparse import add_parser_help
     from conda.cli.helpers import add_parser_prefix
 
-    parser.prog = "conda lockfiles"
     add_parser_prefix(parser, True)
-    add_parser_help(parser)
     parser.add_argument("path", help="Path to pixi.lock file")
     parser.add_argument(
-        "-e", "--environment", default="default", help="Environment name in lockfile"
+        "-e",
+        "--environment",
+        default="default",
+        help="Environment name in lockfile",
     )
     parser.add_argument(
         "-s",
@@ -33,14 +33,13 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 
 def execute(args: argparse.Namespace) -> int:
-    from conda.base.context import context, determine_target_prefix
+    from conda.base.context import context
 
-    from .create import create_environment_from_lockfile
+    from ..create import create_environment_from_lockfile
 
-    prefix = determine_target_prefix(context, args)
     create_environment_from_lockfile(
         lockfile=args.path,
-        prefix=prefix,
+        prefix=context.target_prefix,
         environment=args.environment,
         platform=args.platform,
     )


### PR DESCRIPTION
Refactor `conda_lockfiles.cli` into an extendable subcommand.

Also removes redundant code (e.g., setting `parser.prog`, adding help arg).