### PR TITLE
`conda.common.path.PathType`, `ABC`, and explicit returns

### DIFF
--- a/conda_lockfiles/loaders/base.py
+++ b/conda_lockfiles/loaders/base.py
@@ -8,16 +8,17 @@ from conda.base.context import context
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from conda.common.path import PathType
     from conda.models.records import PackageRecord
 
 
 class BaseLoader:
-    def __init__(self, path: str | Path):
+    def __init__(self, path: PathType):
         self.path = Path(path)
         self.data = self._load(path)
 
     @classmethod
-    def supports(cls, path: str | Path) -> bool:
+    def supports(cls, path: PathType) -> bool:
         raise NotImplementedError
 
     def to_conda_and_pypi(

--- a/conda_lockfiles/loaders/base.py
+++ b/conda_lockfiles/loaders/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from typing import Any
 
     from conda.common.path import PathType
@@ -33,7 +32,7 @@ class BaseLoader(ABC):
         self,
         environment: str | None = None,
         platform: str = context.subdir,
-    ) -> tuple[Iterable[PackageRecord], Iterable[str]]:
+    ) -> tuple[tuple[PackageRecord, ...], tuple[str, ...]]:
         raise NotImplementedError
 
 

--- a/conda_lockfiles/loaders/base.py
+++ b/conda_lockfiles/loaders/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -7,20 +8,27 @@ from conda.base.context import context
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Any
 
     from conda.common.path import PathType
     from conda.models.records import PackageRecord
 
 
-class BaseLoader:
+class BaseLoader(ABC):
     def __init__(self, path: PathType):
         self.path = Path(path)
         self.data = self._load(path)
 
     @classmethod
+    @abstractmethod
     def supports(cls, path: PathType) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def _load(self, path: PathType) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
     def to_conda_and_pypi(
         self,
         environment: str | None = None,

--- a/conda_lockfiles/loaders/pixi.py
+++ b/conda_lockfiles/loaders/pixi.py
@@ -12,7 +12,6 @@ from ruamel.yaml import YAML
 from .base import BaseLoader, build_number_from_build_string
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from typing import Any
 
     from conda.common.path import PathType
@@ -40,7 +39,7 @@ class PixiLoader(BaseLoader):
         self,
         environment: str = "default",
         platform: str = context.subdir,
-    ) -> tuple[Iterable[PackageRecord], Iterable[str]]:
+    ) -> tuple[tuple[PackageRecord, ...], tuple[str, ...]]:
         env = self.data["environments"].get(environment)
         if not env:
             raise ValueError(
@@ -62,7 +61,7 @@ class PixiLoader(BaseLoader):
                 elif package_type == "pypi":
                     pypi.append(url)
 
-        return conda, pypi
+        return tuple(conda), tuple(pypi)
 
     def _package_record_from_conda_url(self, url: str) -> PackageRecord:
         channel, subdir, filename = url.rsplit("/", 2)

--- a/conda_lockfiles/loaders/pixi.py
+++ b/conda_lockfiles/loaders/pixi.py
@@ -15,12 +15,14 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Any
 
+    from conda.common.path import PathType
+
 yaml = YAML(typ="safe")
 
 
 class PixiLoader(BaseLoader):
     @classmethod
-    def supports(cls, path: str | Path) -> bool:
+    def supports(cls, path: PathType) -> bool:
         path = Path(path)
         if path.name != "pixi.lock":
             return False
@@ -30,7 +32,7 @@ class PixiLoader(BaseLoader):
         return True
 
     @staticmethod
-    def _load(path) -> dict[str, Any]:
+    def _load(path: PathType) -> dict[str, Any]:
         with open(path) as f:
             return yaml.load(f)
 


### PR DESCRIPTION
- Refactor `conda_lockfiles.loaders.base.BaseLoader` into an `abc.ABC`.
- Use `conda.common.path.PathType` instead of `str | Path`.
- Prefer explicit return types (e.g., `tuple`) instead of implicit ones (e.g., `Iterable`).