### PR TITLE
Fix argparse help

### DIFF
--- a/conda_lockfiles/cli/__init__.py
+++ b/conda_lockfiles/cli/__init__.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     from .. import APP_NAME, APP_VERSION
+    from .main_create import HELP as CREATE_HELP
     from .main_create import configure_parser as configure_parser_create
+    from .main_export import HELP as EXPORT_HELP
     from .main_export import configure_parser as configure_parser_export
 
     # conda lockfiles --version
@@ -21,16 +23,14 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     )
 
     subparsers = parser.add_subparsers(
-        title="subcommand",
-        description="The following subcommands are available.",
-        dest="cmd",
+        title="subcommands",
+        dest="subcommand",
         required=True,
     )
 
-    configure_parser_create(subparsers.add_parser("create"))
-    configure_parser_export(subparsers.add_parser("export"))
+    configure_parser_create(subparsers.add_parser("create", help=CREATE_HELP))
+    configure_parser_export(subparsers.add_parser("export", help=EXPORT_HELP))
 
 
 def execute(args: argparse.Namespace) -> int:
-    args.func(args)
-    return 0
+    return args.func(args)

--- a/conda_lockfiles/cli/main_create.py
+++ b/conda_lockfiles/cli/main_create.py
@@ -9,10 +9,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import argparse
 
+HELP = "Create a conda environment from a lock file."
+
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     from conda.base.context import context
     from conda.cli.helpers import add_parser_prefix
+
+    parser.description = HELP
 
     add_parser_prefix(parser, True)
     parser.add_argument("path", help="Path to pixi.lock file")

--- a/conda_lockfiles/cli/main_export.py
+++ b/conda_lockfiles/cli/main_export.py
@@ -9,11 +9,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import argparse
 
+HELP = "Export a conda environment to a lock file."
+
 
 def configure_parser(parser: argparse.ArgumentParser):
     from conda.cli.helpers import add_parser_prefix
 
     from ..export import LOCKFILE_FORMATS
+
+    parser.description = HELP
 
     add_parser_prefix(parser, True)
     parser.add_argument(
@@ -28,6 +32,7 @@ def configure_parser(parser: argparse.ArgumentParser):
         dest="lockfile_format",
         choices=LOCKFILE_FORMATS.keys(),
         help="Lockfile format to create.",
+        required=True,
     )
     parser.set_defaults(func=execute)
 


### PR DESCRIPTION
Minor improvement to how argparse renders the help text

### Before
<img width="481" alt="Screenshot 2025-05-08 at 16 06 42" src="https://github.com/user-attachments/assets/c985c9b0-be3c-4ba0-a5de-f59d85ce2ca0" />


### After
<img width="485" alt="Screenshot 2025-05-08 at 16 06 30" src="https://github.com/user-attachments/assets/c34dde0c-4fef-405d-a43a-d4b8c7c09ae2" />
