### PR TITLE
Install conda records directly from lockfile PackageRecord

### DIFF
--- a/conda_lockfiles/loaders/pixi.py
+++ b/conda_lockfiles/loaders/pixi.py
@@ -70,7 +70,7 @@ class PixiLoader(BaseLoader):
             basename = filename[: -len(".tar.bz2")]
             ext = ".tar.bz2"
         elif filename.endswith(".conda"):
-            basename = filename[: -len("conda")]
+            basename = filename[: -len(".conda")]
             ext = ".conda"
         else:
             basename, ext = os.path.splitext(filename)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,3 +8,4 @@ RECIPES_DIR = DATA_DIR / "recipes"
 
 # lockfiles
 PIXI_DIR = DATA_DIR / "pixi"
+PIXI_METADATA_DIR = DATA_DIR / "pixi-metadata"

--- a/tests/data/pixi-metadata/pixi.lock
+++ b/tests/data/pixi-metadata/pixi.lock
@@ -1,0 +1,21 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
+  md5: 4222072737ccff51314b5ece9c7d6f5a
+  license: ONLY_IN_LOCKFILE
+  size: 122968
+  timestamp: 1742727099393

--- a/tests/data/pixi-metadata/pixi.toml
+++ b/tests/data/pixi-metadata/pixi.toml
@@ -1,0 +1,11 @@
+[workspace]
+authors = ["Jonathan Helmus <jjhelmus@gmail.com>"]
+channels = ["conda-forge"]
+name = "pixi-metadata"
+platforms = ["osx-arm64", "linux-64", "win-64", "osx-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+tzdata = ">=2025b,<2026a"

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from conda_lockfiles.create import create_environment_from_lockfile
+
+from . import PIXI_METADATA_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_create_environment_from_lockfile_pixi_metadata(tmp_path: Path) -> None:
+    create_environment_from_lockfile(
+        PIXI_METADATA_DIR / "pixi.lock",
+        tmp_path,
+        environment="default",
+        platform="linux-64",
+    )
+    env_record_path = tmp_path / "conda-meta" / "tzdata-2025b-h78e105d_0.json"
+    assert env_record_path.is_file()
+    data = json.loads(env_record_path.read_bytes())
+    assert data["license"] == "ONLY_IN_LOCKFILE"


### PR DESCRIPTION
Install the conda records directly from the `PackageRecord`s from the lockfile without creating an intermediate explicit file. In this way the metadata from the lockfile is recorded in the environment records.

closes #4