### PR TITLE
Use `--env-spec` argument

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_bug.yml
+++ b/.github/ISSUE_TEMPLATE/0_bug.yml
@@ -28,8 +28,8 @@ body:
       label: Steps to reproduce
       description: Please provide step-by-step instructions to reproduce the issue.
       placeholder: |
-        1. Create environment with `CONDA_ENV_SPEC=conda-lock-v1 conda env create -n test-env path/to/lockfile.yml`
-        2. Try to export with `conda export -n test-env --format conda-lock-v1`
+        1. Create environment with `conda env create -n test-env --env-spec=conda-lock-v1 --file=path/to/lockfile.yml`
+        2. Try to export with `conda export -n test-env --format=conda-lock-v1`
         3. See error...
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The basic usage is:
 
 ```bash
 # Create environment from lockfile
-CONDA_ENV_SPEC=FORMAT conda env create -n ENV-NAME --file=/path/to/lockfile
+conda env create -n ENV-NAME --env-spec=FORMAT --file=/path/to/lockfile
 # Export current environment to lockfile
 conda export -n ENV-NAME --format=FORMAT --file=/path/to/lockfile
 ```

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
         PathFactoryFixture,
         TmpEnvFixture,
     )
-    from pytest import MonkeyPatch
 
 
 @pytest.mark.parametrize(
@@ -39,7 +38,6 @@ def test_export(
     path_factory: PathFactoryFixture,
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
-    monkeypatch: MonkeyPatch,
     format: str,
     filename: str,
     compare: Callable[[Path, Path], bool],
@@ -60,11 +58,11 @@ def test_export(
         assert rc == 0
 
         # create a new environment from the lockfile
-        monkeypatch.setenv("CONDA_ENV_SPEC", format)
         conda_cli(
             "env",
             "create",
             f"--prefix={prefix2}",
+            f"--env-spec={format}",
             f"--file={lockfile}",
         )
 


### PR DESCRIPTION
`CONDA_ENV_SPEC` has an equivalent CLI argument that is more appropriate to use.