### PR TITLE
Build canaries noarch as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,23 +52,11 @@ jobs:
         run: pixi run --environment ${{ env.PIXI_ENV_NAME }} test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
 
   build-conda:
-    name: Build conda package (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Build conda package
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash --noprofile --norc -euo pipefail {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            subdir: linux-64
-          - os: windows-latest
-            subdir: win-64
-          - os: macos-13
-            subdir: osx-64
-          - os: macos-14
-            subdir: osx-arm64
     env:
       PYTHONUNBUFFERED: "1"
       CONDA_BLD_PATH: ${{ github.workspace }}/pkgs
@@ -89,7 +77,6 @@ jobs:
           environments: build
 
       - name: Fix Ubuntu configuration
-        if: startswith(matrix.os, 'ubuntu-')
         run:
           # Remove global pip config that interferes with isolated testing
           # See: https://github.com/actions/runner-images/blob/6d025759810a/images/ubuntu/scripts/build/install-python.sh#L15-L21
@@ -123,7 +110,7 @@ jobs:
           && github.ref_name == 'main'
         shell: bash
         run: |
-          SEARCH_ROOT="$CONDA_BLD_PATH/${{ matrix.subdir }}"
+          SEARCH_ROOT="$CONDA_BLD_PATH/noarch"
           if [[ ! -d "$SEARCH_ROOT" ]]; then
             echo "Expected build output directory $SEARCH_ROOT not found" >&2
             exit 1


### PR DESCRIPTION
Follow-up to #53 which erroneously built canaries as arch-specific, while noarch is totally fine.