### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    allow:
+      # Allow only production updates for Sphinx
+      - dependency-name: sphinx
+        dependency-type: production
+    groups:
+      pip:
+        patterns:
+          - '*'
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: monthly
+    groups:
+      workflows:
+        patterns:
+          - '*'


### PR DESCRIPTION
Enables dependabot for pip and github-actions. Unfortunately dependabot doesn't support pixi.