### PR TITLE
Ensure archive stores git tag info

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # GitHub syntax highlighting
 pixi.lock linguist-language=YAML
+
+# Record git tag for the version when archiving
+.git_archival.txt export-subst


### PR DESCRIPTION
Argh we need this too to get the git tag to be writen to `.git_archival.txt`