### PR TITLE
Add `available_platforms` and `env_for` to lockfile loaders

### DIFF
--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -368,9 +368,3 @@ class CondaLockV1Loader(EnvironmentSpecBase):
                 f"Available platforms: {', '.join(self.available_platforms)}"
             )
         return conda_lock_v1_to_conda_env(self._model, platform=platform)
-
-    @property
-    def multiplatform_envs(self) -> Iterable[Environment]:
-        """Yield one Environment per platform in the lockfile."""
-        for platform in self.available_platforms:
-            yield self.env_for(platform)

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -360,10 +360,17 @@ class CondaLockV1Loader(EnvironmentSpecBase):
             self._validate_model()
         return tuple(self._model.metadata.platforms)
 
+    def env_for(self, platform: str) -> Environment:
+        """Return the Environment for a specific platform in the lockfile."""
+        if platform not in self.available_platforms:
+            raise ValueError(
+                f"Platform {platform!r} not in lockfile. "
+                f"Available platforms: {', '.join(self.available_platforms)}"
+            )
+        return conda_lock_v1_to_conda_env(self._model, platform=platform)
+
     @property
     def multiplatform_envs(self) -> Iterable[Environment]:
         """Yield one Environment per platform in the lockfile."""
-        if self._model is None:
-            self._validate_model()
-        for platform in self._model.metadata.platforms:
-            yield conda_lock_v1_to_conda_env(self._model, platform=platform)
+        for platform in self.available_platforms:
+            yield self.env_for(platform)

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -352,3 +352,18 @@ class CondaLockV1Loader(EnvironmentSpecBase):
             return conda_lock_v1_to_conda_env(self._model)
         except ValueError as e:
             raise CondaValueError(f"\n\nUnable to create environment: {e}") from e
+
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        """Platforms declared in this lockfile."""
+        if self._model is None:
+            self._validate_model()
+        return tuple(self._model.metadata.platforms)
+
+    @property
+    def envs(self) -> Iterable[Environment]:
+        """Yield one Environment per platform in the lockfile."""
+        if self._model is None:
+            self._validate_model()
+        for platform in self._model.metadata.platforms:
+            yield conda_lock_v1_to_conda_env(self._model, platform=platform)

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -361,7 +361,7 @@ class CondaLockV1Loader(EnvironmentSpecBase):
         return tuple(self._model.metadata.platforms)
 
     @property
-    def envs(self) -> Iterable[Environment]:
+    def multiplatform_envs(self) -> Iterable[Environment]:
         """Yield one Environment per platform in the lockfile."""
         if self._model is None:
             self._validate_model()

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -360,10 +360,17 @@ class RattlerLockV6Loader(EnvironmentSpecBase):
             self._validate_model()
         return tuple(sorted(self._model.environments["default"].packages.keys()))
 
+    def env_for(self, platform: str) -> Environment:
+        """Return the Environment for a specific platform in the lockfile."""
+        if platform not in self.available_platforms:
+            raise ValueError(
+                f"Platform {platform!r} not in lockfile. "
+                f"Available platforms: {', '.join(self.available_platforms)}"
+            )
+        return rattler_lock_v6_to_conda_env(self._model, platform=platform)
+
     @property
     def multiplatform_envs(self) -> Iterable[Environment]:
         """Yield one Environment per platform in the lockfile."""
-        if self._model is None:
-            self._validate_model()
         for platform in self.available_platforms:
-            yield rattler_lock_v6_to_conda_env(self._model, platform=platform)
+            yield self.env_for(platform)

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -361,7 +361,7 @@ class RattlerLockV6Loader(EnvironmentSpecBase):
         return tuple(sorted(self._model.environments["default"].packages.keys()))
 
     @property
-    def envs(self) -> Iterable[Environment]:
+    def multiplatform_envs(self) -> Iterable[Environment]:
         """Yield one Environment per platform in the lockfile."""
         if self._model is None:
             self._validate_model()

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -368,9 +368,3 @@ class RattlerLockV6Loader(EnvironmentSpecBase):
                 f"Available platforms: {', '.join(self.available_platforms)}"
             )
         return rattler_lock_v6_to_conda_env(self._model, platform=platform)
-
-    @property
-    def multiplatform_envs(self) -> Iterable[Environment]:
-        """Yield one Environment per platform in the lockfile."""
-        for platform in self.available_platforms:
-            yield self.env_for(platform)

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -352,3 +352,18 @@ class RattlerLockV6Loader(EnvironmentSpecBase):
             return rattler_lock_v6_to_conda_env(self._model)
         except ValueError as e:
             raise CondaValueError(f"\n\nUnable to create environment: {e}") from e
+
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        """Platforms declared in this lockfile."""
+        if self._model is None:
+            self._validate_model()
+        return tuple(sorted(self._model.environments["default"].packages.keys()))
+
+    @property
+    def envs(self) -> Iterable[Environment]:
+        """Yield one Environment per platform in the lockfile."""
+        if self._model is None:
+            self._validate_model()
+        for platform in self.available_platforms:
+            yield rattler_lock_v6_to_conda_env(self._model, platform=platform)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -151,3 +151,50 @@ def test_create_environment_from_rattler_lock_v6(
     assert pkg.license == "ONLY_IN_LOCKFILE"
     assert pkg.size == 122968
     assert pkg.timestamp == 1742727099.393
+
+
+EXPECTED_PLATFORMS = ("linux-64", "osx-64", "osx-arm64", "win-64")
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            (
+                conda_lock_v1.CondaLockV1Loader,
+                CONDA_LOCK_METADATA_DIR / conda_lock_v1.CONDA_LOCK_FILE,
+            ),
+            id="conda-lock-v1",
+        ),
+        pytest.param(
+            (
+                rattler_lock_v6.RattlerLockV6Loader,
+                PIXI_METADATA_DIR / rattler_lock_v6.PIXI_LOCK_FILE,
+            ),
+            id="rattler-lock-v6",
+        ),
+    ],
+)
+def loader(request):
+    cls, path = request.param
+    spec = cls(path)
+    spec.can_handle()
+    return spec
+
+
+def test_available_platforms(loader) -> None:
+    assert loader.available_platforms == EXPECTED_PLATFORMS
+
+
+def test_envs(loader) -> None:
+    envs = list(loader.envs)
+    assert len(envs) == len(EXPECTED_PLATFORMS)
+    assert tuple(e.platform for e in envs) == EXPECTED_PLATFORMS
+    for env in envs:
+        assert env.explicit_packages
+
+
+def test_env_unchanged(loader) -> None:
+    """Regression guard: env still returns a single Environment for context.subdir."""
+    env = loader.env
+    assert env.platform == context.subdir
+    assert env.explicit_packages

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -197,14 +197,6 @@ def test_env_for_unknown_platform_raises(loader) -> None:
         loader.env_for("not-a-real-platform")
 
 
-def test_multiplatform_envs(loader) -> None:
-    envs = list(loader.multiplatform_envs)
-    assert len(envs) == len(EXPECTED_PLATFORMS)
-    assert tuple(e.platform for e in envs) == EXPECTED_PLATFORMS
-    for env in envs:
-        assert env.explicit_packages
-
-
 def test_env_unchanged(loader) -> None:
     """Regression guard: env still returns a single Environment for context.subdir."""
     env = loader.env

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -185,6 +185,18 @@ def test_available_platforms(loader) -> None:
     assert loader.available_platforms == EXPECTED_PLATFORMS
 
 
+@pytest.mark.parametrize("platform", EXPECTED_PLATFORMS)
+def test_env_for(loader, platform) -> None:
+    env = loader.env_for(platform)
+    assert env.platform == platform
+    assert env.explicit_packages
+
+
+def test_env_for_unknown_platform_raises(loader) -> None:
+    with pytest.raises(ValueError, match="not in lockfile"):
+        loader.env_for("not-a-real-platform")
+
+
 def test_multiplatform_envs(loader) -> None:
     envs = list(loader.multiplatform_envs)
     assert len(envs) == len(EXPECTED_PLATFORMS)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -185,8 +185,8 @@ def test_available_platforms(loader) -> None:
     assert loader.available_platforms == EXPECTED_PLATFORMS
 
 
-def test_envs(loader) -> None:
-    envs = list(loader.envs)
+def test_multiplatform_envs(loader) -> None:
+    envs = list(loader.multiplatform_envs)
     assert len(envs) == len(EXPECTED_PLATFORMS)
     assert tuple(e.platform for e in envs) == EXPECTED_PLATFORMS
     for env in envs:


### PR DESCRIPTION
### Description

Adds `available_platforms` and `env_for(platform)` to `CondaLockV1Loader` and `RattlerLockV6Loader`, exposing multi-platform introspection on the loader side.

- `env` is unchanged (single `Environment` for `context.subdir`).
- `available_platforms` returns the full tuple of platforms from the parsed file.
- `env_for(platform)` returns a single `Environment` for the requested platform. Validates against `available_platforms` up front (rattler's `environment.packages.get(platform, ())` otherwise silently returns empty).

Callers iterate with `(loader.env_for(p) for p in loader.available_platforms)` when they want every platform.

Once `EnvironmentSpecBase` in conda core gains default implementations (conda/conda#15928), these become formal overrides rather than ad-hoc extensions.

Closes #127

### Checklist - did you ...

- [x] Add / update necessary tests?
- [ ] ~Add a file to the `news` directory~, no news/changelog convention in this repo
- [ ] ~Add / update outdated documentation~, API mirrors the documented `env` property; docs follow on the conda core side (conda/conda#15928)