### PR TITLE
Add `pixi` / `conda-lock` short aliases and document the alias strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Currently supported lockfile formats:
 - `pixi.lock` — `rattler-lock-v6` (aliases: `pixi`, `pixi-lock-v6`)
 
 The version-pinned names (`-v1`, `-v6`) never change meaning. The short
-aliases track the current-stable version. See [format aliases and bump
-policy](https://conda-incubator.github.io/conda-lockfiles/format-aliases.html)
+aliases track the current-stable version. See [format
+aliases](https://conda-incubator.github.io/conda-lockfiles/format-aliases.html)
 for when to use which.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@ Use **`--format`** with **`conda export`** (output format) and **`--env-spec`** 
 
 Currently supported lockfile formats:
 
-- `conda-lock.yml` — canonical name `conda-lock-v1`, short alias `conda-lock`.
-- `pixi.lock` — canonical name `rattler-lock-v6`, short aliases `pixi` and `pixi-lock-v6`.
+- `conda-lock.yml` / `conda-lock.yaml` — `conda-lock-v1` (alias: `conda-lock`)
+- `pixi.lock` — `rattler-lock-v6` (aliases: `pixi`, `pixi-lock-v6`)
 
-The canonical `-v1` / `-v6` names are the stable contract and never change
-meaning. The short aliases (`conda-lock`, `pixi`) track the current-stable
-format version of each file kind. See [format aliases and bump
+The version-pinned names (`-v1`, `-v6`) never change meaning. The short
+aliases track the current-stable version. See [format aliases and bump
 policy](https://conda-incubator.github.io/conda-lockfiles/format-aliases.html)
-for the full story and for how to re-export an existing file at a new
-format version.
+for when to use which.
 
 ## Installation
 
@@ -102,11 +100,9 @@ conda export --name myenv --format pixi --file pixi.lock
 conda env create --name myenv --file pixi.lock --env-spec=pixi
 ```
 
-`pixi` here is the short alias for the current-stable format
-(`rattler-lock-v6`). When you commit lockfiles or pin exact behaviour in
-CI, prefer the canonical name (`--format rattler-lock-v6`,
-`--env-spec=rattler-lock-v6`) so later conda-lockfiles releases don't
-change the written format under you.
+`pixi` resolves to `rattler-lock-v6` today. Use `--format
+rattler-lock-v6` / `--env-spec=rattler-lock-v6` in committed lockfiles
+and CI so a future alias flip doesn't change the written format.
 <!-- docs-index-content-end -->
 
 More information and example workflows are available on our online [documentation](https://conda-incubator.github.io/conda-lockfiles/).

--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ Use **`--format`** with **`conda export`** (output format) and **`--env-spec`** 
 
 Currently supported lockfile formats:
 
-- conda-lock.yml (`conda-lock-v1`)
-- pixi.lock (`rattler-lock-v6` or `pixi-lock-v6`)
+- `conda-lock.yml` — canonical name `conda-lock-v1`, short alias `conda-lock`.
+- `pixi.lock` — canonical name `rattler-lock-v6`, short aliases `pixi` and `pixi-lock-v6`.
+
+The canonical `-v1` / `-v6` names are the stable contract and never change
+meaning. The short aliases (`conda-lock`, `pixi`) track the current-stable
+format version of each file kind. See [format aliases and bump
+policy](https://conda-incubator.github.io/conda-lockfiles/format-aliases.html)
+for the full story and for how to re-export an existing file at a new
+format version.
 
 ## Installation
 
@@ -91,9 +98,15 @@ conda env create --name myenv --file dev-lock.yml --env-spec=conda-lock-v1
 **Pixi / rattler lock v6**:
 
 ```bash
-conda export --name myenv --format pixi-lock-v6 --file pixi.lock
-conda env create --name myenv --file pixi.lock --env-spec=pixi-lock-v6
+conda export --name myenv --format pixi --file pixi.lock
+conda env create --name myenv --file pixi.lock --env-spec=pixi
 ```
+
+`pixi` here is the short alias for the current-stable format
+(`rattler-lock-v6`). When you commit lockfiles or pin exact behaviour in
+CI, prefer the canonical name (`--format rattler-lock-v6`,
+`--env-spec=rattler-lock-v6`) so later conda-lockfiles releases don't
+change the written format under you.
 <!-- docs-index-content-end -->
 
 More information and example workflows are available on our online [documentation](https://conda-incubator.github.io/conda-lockfiles/).

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -33,8 +33,10 @@ if TYPE_CHECKING:
 #: The name of the conda-lock v1 format.
 FORMAT: Final = "conda-lock-v1"
 
-#: Aliases for the conda-lock v1 format.
-ALIASES: Final = ()
+#: Aliases for the conda-lock v1 format. ``conda-lock`` is the unversioned
+#: convenience alias and tracks the current stable ``conda-lock-v*``
+#: format. See ``docs/format-aliases.md`` for the alias policy.
+ALIASES: Final = ("conda-lock",)
 
 #: The filename of the conda-lock v1 format.
 CONDA_LOCK_FILE: Final = "conda-lock.yml"

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -30,8 +30,11 @@ if TYPE_CHECKING:
 #: The name of the rattler lock v6 format.
 FORMAT: Final = "rattler-lock-v6"
 
-#: Aliases for the rattler lock v6 format.
-ALIASES: Final = ("pixi-lock-v6",)
+#: Aliases for the rattler lock v6 format. ``pixi`` is the unversioned
+#: convenience alias and tracks the current stable ``rattler-lock-v*``
+#: format; ``pixi-lock-v6`` is the version-pinned alias. See
+#: ``docs/format-aliases.md`` for the alias policy.
+ALIASES: Final = ("pixi-lock-v6", "pixi")
 
 #: The filename of the rattler lock v6 format.
 PIXI_LOCK_FILE: Final = "pixi.lock"

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -32,9 +32,10 @@ FORMAT: Final = "rattler-lock-v6"
 
 #: Aliases for the rattler lock v6 format. ``pixi`` is the unversioned
 #: convenience alias and tracks the current stable ``rattler-lock-v*``
-#: format; ``pixi-lock-v6`` is the version-pinned alias. See
-#: ``docs/format-aliases.md`` for the alias policy.
-ALIASES: Final = ("pixi-lock-v6", "pixi")
+#: format; ``pixi-lock-v6`` is the version-pinned alias. The short alias
+#: is listed first so that conda's help text renders it as the display
+#: label. See ``docs/format-aliases.md`` for the alias policy.
+ALIASES: Final = ("pixi", "pixi-lock-v6")
 
 #: The filename of the rattler lock v6 format.
 PIXI_LOCK_FILE: Final = "pixi.lock"

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../../CONTRIBUTING.md
+```

--- a/docs/developer/maintaining.md
+++ b/docs/developer/maintaining.md
@@ -1,0 +1,89 @@
+# Maintaining this project
+
+This page collects workflows that only maintainers need. End-user
+reference on format names and aliases lives in
+[Format names and aliases](../format-aliases).
+
+## Bump policy
+
+When a new version of a format reaches stable, the alias is rolled
+over two releases so the flip is never silent:
+
+1. **Overlap release.** The new canonical name (`rattler-lock-v7`)
+   ships alongside the old one (`rattler-lock-v6`). The unversioned
+   alias (`pixi`) still resolves to the old canonical name. Alias
+   resolution emits a `PendingDeprecationWarning` with wording that
+   names the binding change, not a format deprecation:
+
+   ```
+   PendingDeprecationWarning: 'pixi' currently resolves to
+   rattler-lock-v6 and will resolve to rattler-lock-v7 in
+   conda-lockfiles <version>. Pin --format rattler-lock-v6 to keep
+   writing v6 after the flip.
+   ```
+
+   Python's default filter silences `PendingDeprecationWarning` for
+   end users and shows it in tests and `python -W` runs, which is the
+   right volume for "this alias is about to flip, it may matter to
+   you".
+
+2. **Flip release.** The unversioned alias now resolves to the new
+   canonical name. First alias resolution per process emits a one-shot
+   `DeprecationWarning`:
+
+   ```
+   DeprecationWarning: 'pixi' now resolves to rattler-lock-v7 (was
+   rattler-lock-v6 in the previous release). Pin --format
+   rattler-lock-v6 if you need the old format.
+   ```
+
+   `DeprecationWarning` (not `PendingDeprecationWarning`) because the
+   change has landed and Python's default filter shows it once per
+   location per process, so anyone who did not read the release notes
+   sees the flip exactly once. The old canonical name keeps working;
+   no warning on it.
+
+3. **Removal release.** The old canonical name (`rattler-lock-v6`)
+   enters the standard `conda.deprecations.deprecated` cycle with a
+   concrete `remove_in` target. The one-shot `DeprecationWarning` from
+   step 2 is dropped; the binding is stable again.
+
+Canonical names only participate in step 3. The unversioned alias
+(`pixi`, `conda-lock`) itself is never removed.
+
+The implementation of the warnings in steps 1 and 2 is tracked in
+[#133](https://github.com/conda-incubator/conda-lockfiles/issues/133)
+and will land alongside the first real format bump.
+
+### Maintainer checklist
+
+When shipping a new format version (overlap release):
+
+- Register it under its canonical name in `conda_lockfiles/plugin.py`.
+- Set `default_filenames` to match the previous canonical version
+  (`pixi.lock` stays `pixi.lock`).
+- Leave the unversioned alias pointing at the previous canonical name.
+- When alias resolution picks the unversioned alias, raise
+  `PendingDeprecationWarning` with wording that names the binding
+  change (not a format deprecation) and names the flip release.
+- Announce the upcoming flip in the release notes.
+- Add tests covering both canonical names and confirming the alias
+  still resolves to the previous format.
+- Update the "Names today" table in
+  [Format names and aliases](../format-aliases).
+
+When flipping the alias (flip release):
+
+- Point the unversioned alias at the new canonical name.
+- On first alias resolution per process, raise a one-shot
+  `DeprecationWarning` naming the flip that just happened and pointing
+  at the pin command.
+- Call out the flip in the release notes.
+- Update the "Names today" table.
+
+When retiring the old version (removal release):
+
+- Mark the old canonical name with `conda.deprecations.deprecated` and
+  a removal target.
+- Drop the one-shot `DeprecationWarning` from step 2.
+- Update the "Names today" table.

--- a/docs/format-aliases.md
+++ b/docs/format-aliases.md
@@ -32,10 +32,10 @@ command writes v7.
 
 ## Alias ordering convention
 
-The `ALIASES` tuple in each format module puts the **short unversioned
-alias first**. conda uses the first alias as the display label in
-`--help` output, with the canonical name and any remaining aliases shown
-in parentheses:
+The `ALIASES` tuple in each format module puts the short unversioned
+alias first. conda uses the first alias as the display label in
+`--help` output, with the canonical name and any remaining aliases
+shown in parentheses:
 
 ```
 Lockfiles:
@@ -43,51 +43,118 @@ Lockfiles:
   - conda-lock (conda-lock-v1)
 ```
 
-All names in the tuple — and the canonical name itself — remain valid
+All names in the tuple, and the canonical name itself, remain valid
 everywhere conda accepts a `--format` value. The ordering only affects
 the help label.
 
 When adding a new alias, place the short form first.
 
+## Default filenames across versions
+
+Each format's `default_filenames` is the filename users are already
+typing (`pixi.lock`, `conda-lock.yml`). A new version of the same
+format claims the same filenames; conda-lockfiles does not invent
+`pixi-v7.lock`.
+
+That means two export plugins can register the same `default_filenames`
+entry once a new version ships alongside the old one. `conda export
+--file pixi.lock` (no `--format`) needs conda to pick one. Conda today
+raises `PluginError` on that collision;
+[conda/conda#15963](https://github.com/conda/conda/issues/15963) tracks
+the tiebreaker work so conda picks the current-stable plugin. Until
+that lands, users pass `--format rattler-lock-vN` alongside `--file
+pixi.lock` during the overlap release.
+
+On the read side, `conda env create -f pixi.lock` dispatches on file
+contents. Each specifier's `can_handle()` rejects files it cannot
+parse, so both plugins can coexist without manual disambiguation.
+
+`--file pixi.lock` without `--format` writes current-stable (whatever
+`pixi` currently resolves to) once the tiebreaker in conda/conda#15963
+lands. Pin `--format rattler-lock-v6` when the format version needs to
+outlive the next alias flip.
+
 ## Bump policy
 
-When a new version of a format reaches stable, the alias is rolled over
-two releases so the flip is never silent:
+When a new version of a format reaches stable, the alias is rolled
+over two releases so the flip is never silent:
 
-1. The new canonical name (`rattler-lock-v7`) ships alongside the old
-   one. The unversioned alias (`pixi`) still points at the old version.
-   Alias resolution emits a `PendingDeprecationWarning` naming the
-   release in which the flip lands.
-2. The next release flips the alias to the new canonical name. The old
-   canonical name keeps working without warnings.
-3. At a later release the old canonical name enters the standard
-   `conda.deprecations.DeprecationHandler` cycle with a removal target.
+1. **Overlap release.** The new canonical name (`rattler-lock-v7`)
+   ships alongside the old one (`rattler-lock-v6`). The unversioned
+   alias (`pixi`) still resolves to the old canonical name. Alias
+   resolution emits a `PendingDeprecationWarning` with wording that
+   names the binding change, not a format deprecation:
 
-Canonical names only participate in step 3.
+   ```
+   PendingDeprecationWarning: 'pixi' currently resolves to
+   rattler-lock-v6 and will resolve to rattler-lock-v7 in
+   conda-lockfiles <version>. Pin --format rattler-lock-v6 to keep
+   writing v6 after the flip.
+   ```
+
+   Python's default filter silences `PendingDeprecationWarning` for
+   end users and shows it in tests and `python -W` runs, which is the
+   right volume for "this alias is about to flip, it may matter to
+   you".
+
+2. **Flip release.** The unversioned alias now resolves to the new
+   canonical name. First alias resolution per process emits a one-shot
+   `DeprecationWarning`:
+
+   ```
+   DeprecationWarning: 'pixi' now resolves to rattler-lock-v7 (was
+   rattler-lock-v6 in the previous release). Pin --format
+   rattler-lock-v6 if you need the old format.
+   ```
+
+   `DeprecationWarning` (not `PendingDeprecationWarning`) because the
+   change has landed and Python's default filter shows it once per
+   location per process, so anyone who did not read the release notes
+   sees the flip exactly once. The old canonical name keeps working;
+   no warning on it.
+
+3. **Removal release.** The old canonical name (`rattler-lock-v6`)
+   enters the standard `conda.deprecations.deprecated` cycle with a
+   concrete `remove_in` target. The one-shot `DeprecationWarning` from
+   step 2 is dropped; the binding is stable again.
+
+Canonical names only participate in step 3. The unversioned alias
+(`pixi`, `conda-lock`) itself is never removed.
+
+The implementation of the warnings in steps 1 and 2 is tracked in
+[#133](https://github.com/conda-incubator/conda-lockfiles/issues/133)
+and will land alongside the first real format bump.
 
 ### Maintainer checklist
 
-When shipping a new format version:
+When shipping a new format version (overlap release):
 
 - Register it under its canonical name in `conda_lockfiles/plugin.py`.
+- Set `default_filenames` to match the previous canonical version
+  (`pixi.lock` stays `pixi.lock`).
 - Leave the unversioned alias pointing at the previous canonical name.
-- Emit a `PendingDeprecationWarning` on alias resolution naming the
-  flip release.
+- When alias resolution picks the unversioned alias, raise
+  `PendingDeprecationWarning` with wording that names the binding
+  change (not a format deprecation) and names the flip release.
+- Announce the upcoming flip in the release notes.
 - Add tests covering both canonical names and confirming the alias
   still resolves to the previous format.
 - Update the "Names today" table.
 
-When flipping the alias:
+When flipping the alias (flip release):
 
 - Point the unversioned alias at the new canonical name.
-- Drop the `PendingDeprecationWarning`; call out the flip in the
-  release notes.
+- On first alias resolution per process, raise a one-shot
+  `DeprecationWarning` naming the flip that just happened and pointing
+  at the pin command.
+- Call out the flip in the release notes.
 - Update the "Names today" table.
 
-When retiring the old version:
+When retiring the old version (removal release):
 
 - Mark the old canonical name with `conda.deprecations.deprecated` and
   a removal target.
+- Drop the one-shot `DeprecationWarning` from step 2.
 - Update the "Names today" table.
 
 ## Re-exporting a lockfile at a new format version
@@ -109,65 +176,4 @@ conda export \
 
 Pin the new canonical name in the re-export so the command is
 unaffected by future alias flips. The same pattern works for
-`conda-lock-v1` → a future `conda-lock-v2`.
-
-
-When a new version of a format reaches stable, the alias is rolled over
-two releases so the flip is never silent:
-
-1. The new canonical name (`rattler-lock-v7`) ships alongside the old
-   one. The unversioned alias (`pixi`) still points at the old version.
-   Alias resolution emits a `PendingDeprecationWarning` naming the
-   release in which the flip lands.
-2. The next release flips the alias to the new canonical name. The old
-   canonical name keeps working without warnings.
-3. At a later release the old canonical name enters the standard
-   `conda.deprecations.DeprecationHandler` cycle with a removal target.
-
-Canonical names only participate in step 3.
-
-### Maintainer checklist
-
-When shipping a new format version:
-
-- Register it under its canonical name in `conda_lockfiles/plugin.py`.
-- Leave the unversioned alias pointing at the previous canonical name.
-- Emit a `PendingDeprecationWarning` on alias resolution naming the
-  flip release.
-- Add tests covering both canonical names and confirming the alias
-  still resolves to the previous format.
-- Update the "Names today" table.
-
-When flipping the alias:
-
-- Point the unversioned alias at the new canonical name.
-- Drop the `PendingDeprecationWarning`; call out the flip in the
-  release notes.
-- Update the "Names today" table.
-
-When retiring the old version:
-
-- Mark the old canonical name with `conda.deprecations.deprecated` and
-  a removal target.
-- Update the "Names today" table.
-
-## Re-exporting a lockfile at a new format version
-
-Existing `pixi.lock` files on disk remain valid after an alias flip;
-nothing rewrites them. To upgrade one, re-create the environment from
-the existing file and re-export at the new format:
-
-```shell
-conda env create --name lockfile-upgrade --file pixi.lock
-conda export \
-  --name lockfile-upgrade \
-  --format rattler-lock-v7 \
-  --file pixi.lock \
-  --platform linux-64 \
-  --platform osx-arm64 \
-  --platform win-64
-```
-
-Pin the new canonical name in the re-export so the command is
-unaffected by future alias flips. The same pattern works for
-`conda-lock-v1` → a future `conda-lock-v2`.
+`conda-lock-v1` to a future `conda-lock-v2`.

--- a/docs/format-aliases.md
+++ b/docs/format-aliases.md
@@ -1,113 +1,84 @@
 # Format names and aliases
 
-`conda-lockfiles` exposes each lockfile format under a version-pinned
-canonical name and, where it makes sense, a shorter unversioned alias.
-The two serve different purposes: canonical names are a stable contract,
-aliases are convenience. This document describes which is which today,
-how the alias tracks future format versions, and how to migrate an
-existing lockfile when the alias flips.
+Each lockfile format has a version-pinned canonical name and, when a
+short form reads better at the command line, an unversioned alias.
 
-## Format names today
+## Names today
 
-| Canonical name   | Unversioned alias | Description                                       |
-| ---------------- | ----------------- | ------------------------------------------------- |
-| `conda-lock-v1`  | `conda-lock`      | Multi-platform `conda-lock.yml` / `.yaml` files.  |
-| `rattler-lock-v6`| `pixi`            | `pixi.lock` files produced by the rattler engine. |
+| Canonical name    | Unversioned alias | Files                                |
+| ----------------- | ----------------- | ------------------------------------ |
+| `conda-lock-v1`   | `conda-lock`      | `conda-lock.yml`, `conda-lock.yaml`  |
+| `rattler-lock-v6` | `pixi`            | `pixi.lock`                          |
 
-`rattler-lock-v6` additionally carries `pixi-lock-v6` as a second
-version-pinned alias for backwards compatibility with docs and tooling
-that reference the `pixi-lock-v*` naming.
+`rattler-lock-v6` also accepts `pixi-lock-v6` for compatibility with
+docs and tooling that use the `pixi-lock-v*` naming.
 
-## Canonical vs. unversioned: what the two promise
+## What the two names mean
 
-- **Canonical names (`conda-lock-v1`, `rattler-lock-v6`)** are the stable
-  contract. They identify one specific file-format version and are
-  guaranteed not to move under you: `conda-lock-v1` will always mean the v1
-  spec, even after `conda-lock-v2` ships. Pin these when you care about
-  reproducibility or interoperability with external tooling.
-- **Unversioned aliases (`conda-lock`, `pixi`)** are convenience. They
-  track whatever version is current-stable in the conda-lockfiles release
-  you have installed. Use these in day-to-day commands and docs where the
-  latest stable format is what you want.
+The canonical names (`conda-lock-v1`, `rattler-lock-v6`) identify one
+specific file-format version and never change meaning. `conda-lock-v1`
+will still be `conda-lock-v1` after `conda-lock-v2` ships. Use these in
+committed lockfiles, CI pins, and anywhere a file is exchanged with
+another tool.
 
-If you have a `pixi.lock` file and type `conda export --format pixi`, the
-current release writes `rattler-lock-v6`. After a future release flips the
-alias to, say, `rattler-lock-v7`, the same command writes v7 instead. The
-tutorial below walks through re-exporting an existing file at a new format
-version.
+The unversioned aliases (`conda-lock`, `pixi`) resolve to whichever
+version is current-stable in the installed conda-lockfiles release. Use
+these when you want the latest format and do not need the invocation to
+outlive the next release.
 
-## Alias bump policy
+Concretely: `conda export --format pixi` writes `rattler-lock-v6` today.
+If a later release makes `rattler-lock-v7` current-stable, the same
+command writes v7.
 
-When the current-stable format version changes (e.g. `rattler-lock-v6`
-→ `rattler-lock-v7`), conda-lockfiles rolls the unversioned alias over a
-two-release window so that users who type the short form are warned before
-the output changes:
+## Bump policy
 
-1. **Release _N_ — new version ships pinned.** The new format is added
-   under its canonical name (e.g. `rattler-lock-v7`). The unversioned alias
-   (`pixi`) still resolves to the previous version (`rattler-lock-v6`). A
-   `PendingDeprecationWarning` is emitted on the alias resolution path
-   noting the release in which the flip is planned.
-2. **Release _N+1_ — alias flip.** The unversioned alias is re-pointed to
-   the new canonical version. Users who type the pinned old name
-   (`rattler-lock-v6`) keep getting the old format without warnings. Users
-   who type the pinned new name (`rattler-lock-v7`) or the unversioned
-   alias (`pixi`) get the new format.
-3. **Release _N+K_ — deprecation and removal.** When usage of the old
-   pinned name has dropped off, it enters conda's standard deprecation
-   cycle (`conda.deprecations.DeprecationHandler`) with a clearly stated
-   removal target release.
+When a new version of a format reaches stable, the alias is rolled over
+two releases so the flip is never silent:
 
-Canonical names only participate in step 3. They never silently change
-meaning.
+1. The new canonical name (`rattler-lock-v7`) ships alongside the old
+   one. The unversioned alias (`pixi`) still points at the old version.
+   Alias resolution emits a `PendingDeprecationWarning` naming the
+   release in which the flip lands.
+2. The next release flips the alias to the new canonical name. The old
+   canonical name keeps working without warnings.
+3. At a later release the old canonical name enters the standard
+   `conda.deprecations.DeprecationHandler` cycle with a removal target.
 
-### Maintainer checklist for a version bump
+Canonical names only participate in step 3.
 
-Pre-bump:
+### Maintainer checklist
 
-- [ ] Add the new format module under its canonical name and register it
-      in `conda_lockfiles/plugin.py` alongside the existing one.
-- [ ] Keep the existing unversioned alias pointing at the previous
-      canonical name.
-- [ ] Wire a `PendingDeprecationWarning` on unversioned-alias resolution
-      that names the upcoming flip release.
-- [ ] Add tests that (a) both canonical names resolve, and (b) the
-      unversioned alias still resolves to the previous format.
-- [ ] Update this document's "Format names today" table with a row for the
-      new canonical name, and add a note that the unversioned alias flip
-      is scheduled for release _N+1_.
+When shipping a new format version:
 
-Bump release:
+- Register it under its canonical name in `conda_lockfiles/plugin.py`.
+- Leave the unversioned alias pointing at the previous canonical name.
+- Emit a `PendingDeprecationWarning` on alias resolution naming the
+  flip release.
+- Add tests covering both canonical names and confirming the alias
+  still resolves to the previous format.
+- Update the "Names today" table.
 
-- [ ] Move the unversioned alias to the new canonical format.
-- [ ] Swap the `PendingDeprecationWarning` for a release-note entry
-      describing the flip.
-- [ ] Update this document: the unversioned alias now tracks the new
-      version; the previous version stays supported under its pinned name.
+When flipping the alias:
 
-Deprecation release:
+- Point the unversioned alias at the new canonical name.
+- Drop the `PendingDeprecationWarning`; call out the flip in the
+  release notes.
+- Update the "Names today" table.
 
-- [ ] Mark the old canonical name via `conda.deprecations.deprecated` with
-      a concrete removal target.
-- [ ] Update this document to list the name as deprecated.
+When retiring the old version:
 
-## Tutorial: re-exporting an existing lockfile at a new format version
+- Mark the old canonical name with `conda.deprecations.deprecated` and
+  a removal target.
+- Update the "Names today" table.
 
-If a future release flips `pixi` from `rattler-lock-v6` to
-`rattler-lock-v7`, an existing `pixi.lock` on disk is still valid — nothing
-rewrites files on your behalf. To move it to the new format, re-export
-from an environment that matches the lockfile.
+## Re-exporting a lockfile at a new format version
 
-Re-create the environment from the existing file:
+Existing `pixi.lock` files on disk remain valid after an alias flip;
+nothing rewrites them. To upgrade one, re-create the environment from
+the existing file and re-export at the new format:
 
 ```shell
 conda env create --name lockfile-upgrade --file pixi.lock
-```
-
-Export it at the new format. Pin the new version explicitly so the command
-keeps doing the same thing regardless of future alias flips:
-
-```shell
 conda export \
   --name lockfile-upgrade \
   --format rattler-lock-v7 \
@@ -117,27 +88,6 @@ conda export \
   --platform win-64
 ```
 
-The same pattern applies to `conda-lock-v1` → `conda-lock-v2` once that
-version exists; substitute the canonical names accordingly.
-
-If you want the short form during an alias-flip window:
-
-```shell
-conda export --name lockfile-upgrade --format pixi --file pixi.lock ...
-```
-
-This writes whatever the current release of conda-lockfiles treats as
-`pixi`-stable. The current mapping is recorded in the "Format names today"
-table above.
-
-## Picking the right name for your situation
-
-- **Committing lockfiles to a repo or pinning in CI.** Use the canonical
-  name (`conda-lock-v1`, `rattler-lock-v6`). The invocation is stable
-  across conda-lockfiles releases.
-- **Ad-hoc commands, docs, READMEs.** Use the unversioned alias
-  (`conda-lock`, `pixi`). The short form is what most users recognise and
-  it keeps tracking the current-stable format.
-- **Tooling that exchanges files with `conda-lock` or `pixi` directly.**
-  Use the canonical name matching the file-format version the other tool
-  understands.
+Pin the new canonical name in the re-export so the command is
+unaffected by future alias flips. The same pattern works for
+`conda-lock-v1` → a future `conda-lock-v2`.

--- a/docs/format-aliases.md
+++ b/docs/format-aliases.md
@@ -1,0 +1,143 @@
+# Format names and aliases
+
+`conda-lockfiles` exposes each lockfile format under a version-pinned
+canonical name and, where it makes sense, a shorter unversioned alias.
+The two serve different purposes: canonical names are a stable contract,
+aliases are convenience. This document describes which is which today,
+how the alias tracks future format versions, and how to migrate an
+existing lockfile when the alias flips.
+
+## Format names today
+
+| Canonical name   | Unversioned alias | Description                                       |
+| ---------------- | ----------------- | ------------------------------------------------- |
+| `conda-lock-v1`  | `conda-lock`      | Multi-platform `conda-lock.yml` / `.yaml` files.  |
+| `rattler-lock-v6`| `pixi`            | `pixi.lock` files produced by the rattler engine. |
+
+`rattler-lock-v6` additionally carries `pixi-lock-v6` as a second
+version-pinned alias for backwards compatibility with docs and tooling
+that reference the `pixi-lock-v*` naming.
+
+## Canonical vs. unversioned: what the two promise
+
+- **Canonical names (`conda-lock-v1`, `rattler-lock-v6`)** are the stable
+  contract. They identify one specific file-format version and are
+  guaranteed not to move under you: `conda-lock-v1` will always mean the v1
+  spec, even after `conda-lock-v2` ships. Pin these when you care about
+  reproducibility or interoperability with external tooling.
+- **Unversioned aliases (`conda-lock`, `pixi`)** are convenience. They
+  track whatever version is current-stable in the conda-lockfiles release
+  you have installed. Use these in day-to-day commands and docs where the
+  latest stable format is what you want.
+
+If you have a `pixi.lock` file and type `conda export --format pixi`, the
+current release writes `rattler-lock-v6`. After a future release flips the
+alias to, say, `rattler-lock-v7`, the same command writes v7 instead. The
+tutorial below walks through re-exporting an existing file at a new format
+version.
+
+## Alias bump policy
+
+When the current-stable format version changes (e.g. `rattler-lock-v6`
+→ `rattler-lock-v7`), conda-lockfiles rolls the unversioned alias over a
+two-release window so that users who type the short form are warned before
+the output changes:
+
+1. **Release _N_ — new version ships pinned.** The new format is added
+   under its canonical name (e.g. `rattler-lock-v7`). The unversioned alias
+   (`pixi`) still resolves to the previous version (`rattler-lock-v6`). A
+   `PendingDeprecationWarning` is emitted on the alias resolution path
+   noting the release in which the flip is planned.
+2. **Release _N+1_ — alias flip.** The unversioned alias is re-pointed to
+   the new canonical version. Users who type the pinned old name
+   (`rattler-lock-v6`) keep getting the old format without warnings. Users
+   who type the pinned new name (`rattler-lock-v7`) or the unversioned
+   alias (`pixi`) get the new format.
+3. **Release _N+K_ — deprecation and removal.** When usage of the old
+   pinned name has dropped off, it enters conda's standard deprecation
+   cycle (`conda.deprecations.DeprecationHandler`) with a clearly stated
+   removal target release.
+
+Canonical names only participate in step 3. They never silently change
+meaning.
+
+### Maintainer checklist for a version bump
+
+Pre-bump:
+
+- [ ] Add the new format module under its canonical name and register it
+      in `conda_lockfiles/plugin.py` alongside the existing one.
+- [ ] Keep the existing unversioned alias pointing at the previous
+      canonical name.
+- [ ] Wire a `PendingDeprecationWarning` on unversioned-alias resolution
+      that names the upcoming flip release.
+- [ ] Add tests that (a) both canonical names resolve, and (b) the
+      unversioned alias still resolves to the previous format.
+- [ ] Update this document's "Format names today" table with a row for the
+      new canonical name, and add a note that the unversioned alias flip
+      is scheduled for release _N+1_.
+
+Bump release:
+
+- [ ] Move the unversioned alias to the new canonical format.
+- [ ] Swap the `PendingDeprecationWarning` for a release-note entry
+      describing the flip.
+- [ ] Update this document: the unversioned alias now tracks the new
+      version; the previous version stays supported under its pinned name.
+
+Deprecation release:
+
+- [ ] Mark the old canonical name via `conda.deprecations.deprecated` with
+      a concrete removal target.
+- [ ] Update this document to list the name as deprecated.
+
+## Tutorial: re-exporting an existing lockfile at a new format version
+
+If a future release flips `pixi` from `rattler-lock-v6` to
+`rattler-lock-v7`, an existing `pixi.lock` on disk is still valid — nothing
+rewrites files on your behalf. To move it to the new format, re-export
+from an environment that matches the lockfile.
+
+Re-create the environment from the existing file:
+
+```shell
+conda env create --name lockfile-upgrade --file pixi.lock
+```
+
+Export it at the new format. Pin the new version explicitly so the command
+keeps doing the same thing regardless of future alias flips:
+
+```shell
+conda export \
+  --name lockfile-upgrade \
+  --format rattler-lock-v7 \
+  --file pixi.lock \
+  --platform linux-64 \
+  --platform osx-arm64 \
+  --platform win-64
+```
+
+The same pattern applies to `conda-lock-v1` → `conda-lock-v2` once that
+version exists; substitute the canonical names accordingly.
+
+If you want the short form during an alias-flip window:
+
+```shell
+conda export --name lockfile-upgrade --format pixi --file pixi.lock ...
+```
+
+This writes whatever the current release of conda-lockfiles treats as
+`pixi`-stable. The current mapping is recorded in the "Format names today"
+table above.
+
+## Picking the right name for your situation
+
+- **Committing lockfiles to a repo or pinning in CI.** Use the canonical
+  name (`conda-lock-v1`, `rattler-lock-v6`). The invocation is stable
+  across conda-lockfiles releases.
+- **Ad-hoc commands, docs, READMEs.** Use the unversioned alias
+  (`conda-lock`, `pixi`). The short form is what most users recognise and
+  it keeps tracking the current-stable format.
+- **Tooling that exchanges files with `conda-lock` or `pixi` directly.**
+  Use the canonical name matching the file-format version the other tool
+  understands.

--- a/docs/format-aliases.md
+++ b/docs/format-aliases.md
@@ -63,7 +63,7 @@ raises `PluginError` on that collision;
 [conda/conda#15963](https://github.com/conda/conda/issues/15963) tracks
 the tiebreaker work so conda picks the current-stable plugin. Until
 that lands, users pass `--format rattler-lock-vN` alongside `--file
-pixi.lock` during the overlap release.
+pixi.lock` to disambiguate.
 
 On the read side, `conda env create -f pixi.lock` dispatches on file
 contents. Each specifier's `can_handle()` rejects files it cannot
@@ -73,89 +73,6 @@ parse, so both plugins can coexist without manual disambiguation.
 `pixi` currently resolves to) once the tiebreaker in conda/conda#15963
 lands. Pin `--format rattler-lock-v6` when the format version needs to
 outlive the next alias flip.
-
-## Bump policy
-
-When a new version of a format reaches stable, the alias is rolled
-over two releases so the flip is never silent:
-
-1. **Overlap release.** The new canonical name (`rattler-lock-v7`)
-   ships alongside the old one (`rattler-lock-v6`). The unversioned
-   alias (`pixi`) still resolves to the old canonical name. Alias
-   resolution emits a `PendingDeprecationWarning` with wording that
-   names the binding change, not a format deprecation:
-
-   ```
-   PendingDeprecationWarning: 'pixi' currently resolves to
-   rattler-lock-v6 and will resolve to rattler-lock-v7 in
-   conda-lockfiles <version>. Pin --format rattler-lock-v6 to keep
-   writing v6 after the flip.
-   ```
-
-   Python's default filter silences `PendingDeprecationWarning` for
-   end users and shows it in tests and `python -W` runs, which is the
-   right volume for "this alias is about to flip, it may matter to
-   you".
-
-2. **Flip release.** The unversioned alias now resolves to the new
-   canonical name. First alias resolution per process emits a one-shot
-   `DeprecationWarning`:
-
-   ```
-   DeprecationWarning: 'pixi' now resolves to rattler-lock-v7 (was
-   rattler-lock-v6 in the previous release). Pin --format
-   rattler-lock-v6 if you need the old format.
-   ```
-
-   `DeprecationWarning` (not `PendingDeprecationWarning`) because the
-   change has landed and Python's default filter shows it once per
-   location per process, so anyone who did not read the release notes
-   sees the flip exactly once. The old canonical name keeps working;
-   no warning on it.
-
-3. **Removal release.** The old canonical name (`rattler-lock-v6`)
-   enters the standard `conda.deprecations.deprecated` cycle with a
-   concrete `remove_in` target. The one-shot `DeprecationWarning` from
-   step 2 is dropped; the binding is stable again.
-
-Canonical names only participate in step 3. The unversioned alias
-(`pixi`, `conda-lock`) itself is never removed.
-
-The implementation of the warnings in steps 1 and 2 is tracked in
-[#133](https://github.com/conda-incubator/conda-lockfiles/issues/133)
-and will land alongside the first real format bump.
-
-### Maintainer checklist
-
-When shipping a new format version (overlap release):
-
-- Register it under its canonical name in `conda_lockfiles/plugin.py`.
-- Set `default_filenames` to match the previous canonical version
-  (`pixi.lock` stays `pixi.lock`).
-- Leave the unversioned alias pointing at the previous canonical name.
-- When alias resolution picks the unversioned alias, raise
-  `PendingDeprecationWarning` with wording that names the binding
-  change (not a format deprecation) and names the flip release.
-- Announce the upcoming flip in the release notes.
-- Add tests covering both canonical names and confirming the alias
-  still resolves to the previous format.
-- Update the "Names today" table.
-
-When flipping the alias (flip release):
-
-- Point the unversioned alias at the new canonical name.
-- On first alias resolution per process, raise a one-shot
-  `DeprecationWarning` naming the flip that just happened and pointing
-  at the pin command.
-- Call out the flip in the release notes.
-- Update the "Names today" table.
-
-When retiring the old version (removal release):
-
-- Mark the old canonical name with `conda.deprecations.deprecated` and
-  a removal target.
-- Drop the one-shot `DeprecationWarning` from step 2.
-- Update the "Names today" table.
 
 ## Re-exporting a lockfile at a new format version
 

--- a/docs/format-aliases.md
+++ b/docs/format-aliases.md
@@ -30,7 +30,87 @@ Concretely: `conda export --format pixi` writes `rattler-lock-v6` today.
 If a later release makes `rattler-lock-v7` current-stable, the same
 command writes v7.
 
+## Alias ordering convention
+
+The `ALIASES` tuple in each format module puts the **short unversioned
+alias first**. conda uses the first alias as the display label in
+`--help` output, with the canonical name and any remaining aliases shown
+in parentheses:
+
+```
+Lockfiles:
+  - pixi (rattler-lock-v6, pixi-lock-v6)
+  - conda-lock (conda-lock-v1)
+```
+
+All names in the tuple — and the canonical name itself — remain valid
+everywhere conda accepts a `--format` value. The ordering only affects
+the help label.
+
+When adding a new alias, place the short form first.
+
 ## Bump policy
+
+When a new version of a format reaches stable, the alias is rolled over
+two releases so the flip is never silent:
+
+1. The new canonical name (`rattler-lock-v7`) ships alongside the old
+   one. The unversioned alias (`pixi`) still points at the old version.
+   Alias resolution emits a `PendingDeprecationWarning` naming the
+   release in which the flip lands.
+2. The next release flips the alias to the new canonical name. The old
+   canonical name keeps working without warnings.
+3. At a later release the old canonical name enters the standard
+   `conda.deprecations.DeprecationHandler` cycle with a removal target.
+
+Canonical names only participate in step 3.
+
+### Maintainer checklist
+
+When shipping a new format version:
+
+- Register it under its canonical name in `conda_lockfiles/plugin.py`.
+- Leave the unversioned alias pointing at the previous canonical name.
+- Emit a `PendingDeprecationWarning` on alias resolution naming the
+  flip release.
+- Add tests covering both canonical names and confirming the alias
+  still resolves to the previous format.
+- Update the "Names today" table.
+
+When flipping the alias:
+
+- Point the unversioned alias at the new canonical name.
+- Drop the `PendingDeprecationWarning`; call out the flip in the
+  release notes.
+- Update the "Names today" table.
+
+When retiring the old version:
+
+- Mark the old canonical name with `conda.deprecations.deprecated` and
+  a removal target.
+- Update the "Names today" table.
+
+## Re-exporting a lockfile at a new format version
+
+Existing `pixi.lock` files on disk remain valid after an alias flip;
+nothing rewrites them. To upgrade one, re-create the environment from
+the existing file and re-export at the new format:
+
+```shell
+conda env create --name lockfile-upgrade --file pixi.lock
+conda export \
+  --name lockfile-upgrade \
+  --format rattler-lock-v7 \
+  --file pixi.lock \
+  --platform linux-64 \
+  --platform osx-arm64 \
+  --platform win-64
+```
+
+Pin the new canonical name in the re-export so the command is
+unaffected by future alias flips. The same pattern works for
+`conda-lock-v1` → a future `conda-lock-v2`.
+
 
 When a new version of a format reaches stable, the alias is rolled over
 two releases so the flip is never silent:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ conda env create --name my-env --file dev.yml --env-spec=conda-lock-v1
 :::{tip}
 `conda-lock` and `pixi` resolve to `conda-lock-v1` and `rattler-lock-v6`
 today. Use the version-pinned names in committed lockfiles and CI. See
-[format aliases and bump policy](format-aliases.md).
+[format aliases](format-aliases.md).
 :::
 
 :::{warning}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,8 +18,18 @@ conda create --name my-env --file dev.conda-lock.yml
 conda env create --name my-env  --file pixi.lock
 
 # If the format is not detected from the filename:
+conda env create --name my-env --file dev.yml --env-spec=conda-lock
+# or, equivalently, using the canonical version-pinned name:
 conda env create --name my-env --file dev.yml --env-spec=conda-lock-v1
 ```
+
+:::{tip}
+`conda-lock` and `pixi` are short aliases for the current-stable
+format versions (`conda-lock-v1` and `rattler-lock-v6` respectively). The
+version-pinned names are the stable contract — prefer them when you commit
+lockfiles or need reproducible behaviour across conda-lockfiles releases.
+See [format aliases and bump policy](format-aliases.md).
+:::
 
 :::{warning}
 Only version 6 format of the pixi lock file is supported. Earlier versions may cause errors.
@@ -69,7 +79,9 @@ conda create --name python-env --yes python
 it's possible to export it to a lockfile using the `win-64` platform with the following command:
 
 ```shell
-conda export --name python-env --format pixi-lock-v6 --platform win-64 --file pixi.lock
+conda export --name python-env --format pixi --platform win-64 --file pixi.lock
+# or with the version-pinned name:
+conda export --name python-env --format rattler-lock-v6 --platform win-64 --file pixi.lock
 ```
 
 :::{warning}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,11 +24,9 @@ conda env create --name my-env --file dev.yml --env-spec=conda-lock-v1
 ```
 
 :::{tip}
-`conda-lock` and `pixi` are short aliases for the current-stable
-format versions (`conda-lock-v1` and `rattler-lock-v6` respectively). The
-version-pinned names are the stable contract — prefer them when you commit
-lockfiles or need reproducible behaviour across conda-lockfiles releases.
-See [format aliases and bump policy](format-aliases.md).
+`conda-lock` and `pixi` resolve to `conda-lock-v1` and `rattler-lock-v6`
+today. Use the version-pinned names in committed lockfiles and CI. See
+[format aliases and bump policy](format-aliases.md).
 :::
 
 :::{warning}

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ New to `conda-lockfiles`? Start here to learn the essentials
 :::{grid-item-card} 🏷️ Format aliases
 :link: format-aliases
 :link-type: doc
-Canonical names vs. short aliases, bump policy, re-export tutorial
+Canonical names vs. short aliases, re-export tutorial
 :::
 
 :::{grid-item-card} 💡 Motivation and vision
@@ -44,4 +44,12 @@ Read about why `conda-lockfiles` exists and when you should use it
 getting-started
 format-aliases
 motivation
+```
+
+```{toctree}
+:caption: Developer
+:hidden:
+
+developer/contributing
+developer/maintaining
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,12 @@ Please submit bug reports or feature requests [here](https://github.com/conda-in
 New to `conda-lockfiles`? Start here to learn the essentials
 :::
 
+:::{grid-item-card} 🏷️ Format aliases
+:link: format-aliases
+:link-type: doc
+Canonical names vs. short aliases, bump policy, re-export tutorial
+:::
+
 :::{grid-item-card} 💡 Motivation and vision
 :link: motivation
 :link-type: doc
@@ -36,5 +42,6 @@ Read about why `conda-lockfiles` exists and when you should use it
 :hidden:
 
 getting-started
+format-aliases
 motivation
 ```

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -85,6 +85,44 @@ def test_exporter_plugin_metadata(
     assert exporter.environment_format == EnvironmentFormat.lockfile
 
 
+@pytest.mark.parametrize(
+    "alias,canonical_format",
+    [
+        ("conda-lock", conda_lock_v1.FORMAT),
+        ("pixi-lock-v6", rattler_lock_v6.FORMAT),
+        ("pixi", rattler_lock_v6.FORMAT),
+    ],
+)
+def test_specifier_alias_resolves(
+    plugin_manager: CondaPluginManager,
+    alias: str,
+    canonical_format: str,
+) -> None:
+    """Aliases resolve to the same plugin as the canonical format name."""
+    specifiers = plugin_manager.get_environment_specifiers()
+    assert alias in specifiers
+    assert specifiers[alias].name == canonical_format
+
+
+@pytest.mark.parametrize(
+    "alias,canonical_format",
+    [
+        ("conda-lock", conda_lock_v1.FORMAT),
+        ("pixi-lock-v6", rattler_lock_v6.FORMAT),
+        ("pixi", rattler_lock_v6.FORMAT),
+    ],
+)
+def test_exporter_alias_resolves(
+    plugin_manager: CondaPluginManager,
+    alias: str,
+    canonical_format: str,
+) -> None:
+    """`conda export --format <alias>` resolves to the canonical exporter."""
+    exporter = plugin_manager.get_environment_exporter_by_format(alias)
+    assert exporter is not None
+    assert exporter.name == canonical_format
+
+
 def test_create_environment_from_conda_lock_v1(
     plugin_manager: CondaPluginManager,
 ) -> None:


### PR DESCRIPTION
Closes #45.

## What

Two changes that land the open alias-strategy question as a concrete decision in code and docs.

### Code

- `conda-lock-v1` now carries `conda-lock` as an unversioned alias.
- `rattler-lock-v6` now carries `pixi` as an unversioned alias (alongside the existing `pixi-lock-v6`).
- Added parametrized tests that both specifier and exporter alias lookups resolve to the canonical plugin for `conda-lock`, `pixi`, and `pixi-lock-v6`.

### Docs

New `docs/format-aliases.md` covers what was previously implicit:

1. **Which names resolve to what today.** Canonical names (`conda-lock-v1`, `rattler-lock-v6`) are the stable contract and never change meaning. Unversioned aliases (`conda-lock`, `pixi`) are convenience and track whichever version is current-stable in the installed release.
2. **Alias bump policy for future format versions.** Concrete maintainer checklist over a two-release window: ship the new canonical version pinned while the alias still points at the old one and emits a `PendingDeprecationWarning`, flip the alias in the next release, then deprecate the old pinned name on the standard `conda.deprecations.DeprecationHandler` cycle. Canonical names only participate in step 3, never silently move.
3. **User-facing tutorial for re-exporting at a new format version** — walks through `conda env create` → `conda export --format <canonical>` so readers have a copy-pasteable recipe for when the alias flips.

`README.md` and `docs/getting-started.md` now default their examples to the short aliases with a pointer to the canonical names for CI and committed lockfiles. `docs/index.md` wires the new page into the toctree and the landing-page grid.

## Why

Background in conda/conda#15928 (specifically the error-message review with @soapy1) and #45. Users today have to type `--format pixi-lock-v6` or `--format conda-lock-v1` in commands and error hints even though each ecosystem has exactly one stable version, which makes copy-pasted commands look noisier than they need to be. The unversioned aliases (`pixi`, `conda-lock`) close that gap; the doc makes the contract around them explicit so we can add more versioned formats later without surprising anyone who types the short form.

## Notes on scope

The `PendingDeprecationWarning` wiring is described in the policy but not implemented yet — it is not needed until the first version bump lands and would otherwise be dead code. The maintainer checklist names the hook point so it is easy to plug in at the right time.

## Test plan

- [x] `pixi run -e test-py313 test tests/test_loaders.py -q` passes (the 5 `test_roundtrip.py` `NoChannelsConfiguredError` failures reproduce on clean `main` and are unrelated).
- [x] `pixi run -e docs docs` builds clean, including the new page.
- [x] `pixi run -e test-py313 pre-commit` passes.