### PR TITLE
Record environment intent in exported lockfiles

### DIFF
--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -251,9 +251,7 @@ def conda_lock_v1_from_conda_envs(envs: Iterable[Environment]) -> CondaLockV1:
         requested.update(requested_specs_from_prefix(e.prefix))
     custom_metadata = CondaLockV1CustomMetadata(
         created_by=f"conda-lockfiles {__version__}",
-        requested_specs=(
-            json.dumps(sorted(requested)) if requested else None
-        ),
+        requested_specs=(json.dumps(sorted(requested)) if requested else None),
     )
 
     metadata = CondaLockV1Metadata(

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -104,6 +104,28 @@ class CondaLockV1TimeMetadata(BaseModel):
     created_at: str
 
 
+class CondaLockV1CustomMetadata(BaseModel):
+    """Custom metadata block for the conda-lock v1 lockfile.
+
+    CEP 37 specifies ``custom_metadata`` as ``dict[str, str]`` (free-form
+    key-value string pairs), so on the wire this is still a flat string
+    map. We model it as a typed ``BaseModel`` with a couple of well-known
+    fields plus ``extra="allow"`` so callers can round-trip arbitrary
+    extra keys without us losing track of them.
+
+    Structured payloads (e.g. the :data:`REQUESTED_SPECS_KEY` list of
+    ``MatchSpec`` strings) are JSON-encoded into a single string to
+    satisfy the ``dict[str, str]`` constraint required for interop with
+    ``conda-lock`` (whose pydantic model is ``StrictModel`` and rejects
+    non-string values here).
+    """
+
+    model_config = {"extra": "allow"}
+
+    created_by: str | None = None
+    requested_specs: str | None = None
+
+
 class CondaLockV1Metadata(BaseModel):
     """Metadata section of the conda-lock v1 lockfile."""
 
@@ -112,10 +134,7 @@ class CondaLockV1Metadata(BaseModel):
     platforms: Annotated[list[str], Field(min_length=1)]
     sources: Annotated[list[str], Field(default_factory=list)]
     time_metadata: CondaLockV1TimeMetadata | None = None
-    # Free-form ``dict[str, str]`` per CEP 37. Values must be strings, so
-    # structured payloads (e.g. the ``requested_specs`` list) are stored as
-    # JSON-encoded strings. See :data:`REQUESTED_SPECS_KEY`.
-    custom_metadata: dict[str, str] | None = None
+    custom_metadata: CondaLockV1CustomMetadata | None = None
 
 
 class CondaLockV1(BaseModel):
@@ -230,11 +249,12 @@ def conda_lock_v1_from_conda_envs(envs: Iterable[Environment]) -> CondaLockV1:
     requested: set[str] = set()
     for e in env_list:
         requested.update(requested_specs_from_prefix(e.prefix))
-    custom_metadata: dict[str, str] = {
-        "created_by": f"conda-lockfiles {__version__}",
-    }
-    if requested:
-        custom_metadata[REQUESTED_SPECS_KEY] = json.dumps(sorted(requested))
+    custom_metadata = CondaLockV1CustomMetadata(
+        created_by=f"conda-lockfiles {__version__}",
+        requested_specs=(
+            json.dumps(sorted(requested)) if requested else None
+        ),
+    )
 
     metadata = CondaLockV1Metadata(
         content_hash={},  # Empty for now, could be computed later
@@ -260,9 +280,9 @@ def _requested_packages_from_metadata(
     with a warning; ``Environment.__post_init__`` would otherwise reject
     the whole object.
     """
-    if not metadata.custom_metadata:
+    if metadata.custom_metadata is None:
         return []
-    raw = metadata.custom_metadata.get(REQUESTED_SPECS_KEY)
+    raw = metadata.custom_metadata.requested_specs
     if not raw:
         return []
     try:

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +19,7 @@ from ruamel.yaml.parser import ParserError
 
 from .. import __version__
 from ..exceptions import CondaLockfilesParserError, CondaLockfilesValidationError
+from ..history import requested_specs_from_prefix
 from ..load_yaml import load_yaml
 from ..records_from_conda_urls import records_from_conda_urls
 from ..validate_urls import validate_urls
@@ -61,6 +63,12 @@ PIP_EXPORT_WARNING: Final = (
     "  2. Install the pip packages manually after applying the lockfile"
 )
 
+#: Key under ``metadata.custom_metadata`` that carries a JSON-encoded list of
+#: user-requested ``MatchSpec`` strings. Named to match CEP 32's
+#: ``requested_specs`` terminology; stored as a JSON string because
+#: ``custom_metadata`` is constrained to ``dict[str, str]`` by CEP 37.
+REQUESTED_SPECS_KEY: Final = "requested_specs"
+
 
 class CondaLockV1Hash(BaseModel):
     """Hash information for a package."""
@@ -96,12 +104,6 @@ class CondaLockV1TimeMetadata(BaseModel):
     created_at: str
 
 
-class CondaLockV1CustomMetadata(BaseModel):
-    """Custom metadata for the lockfile."""
-
-    created_by: str
-
-
 class CondaLockV1Metadata(BaseModel):
     """Metadata section of the conda-lock v1 lockfile."""
 
@@ -110,7 +112,10 @@ class CondaLockV1Metadata(BaseModel):
     platforms: Annotated[list[str], Field(min_length=1)]
     sources: Annotated[list[str], Field(default_factory=list)]
     time_metadata: CondaLockV1TimeMetadata | None = None
-    custom_metadata: CondaLockV1CustomMetadata | None = None
+    # Free-form ``dict[str, str]`` per CEP 37. Values must be strings, so
+    # structured payloads (e.g. the ``requested_specs`` list) are stored as
+    # JSON-encoded strings. See :data:`REQUESTED_SPECS_KEY`.
+    custom_metadata: dict[str, str] | None = None
 
 
 class CondaLockV1(BaseModel):
@@ -218,19 +223,70 @@ def conda_lock_v1_from_conda_envs(envs: Iterable[Environment]) -> CondaLockV1:
         for channel in env.config.channels
     ]
 
+    # Record user intent in custom_metadata. We re-derive from the prefix's
+    # history rather than trusting env.requested_packages, which conda
+    # populates with the full install list by default (conda/conda#15961).
+    # Union specs across environments so multi-platform exports keep them.
+    requested: set[str] = set()
+    for e in env_list:
+        requested.update(requested_specs_from_prefix(e.prefix))
+    custom_metadata: dict[str, str] = {
+        "created_by": f"conda-lockfiles {__version__}",
+    }
+    if requested:
+        custom_metadata[REQUESTED_SPECS_KEY] = json.dumps(sorted(requested))
+
     metadata = CondaLockV1Metadata(
         content_hash={},  # Empty for now, could be computed later
         channels=channels,
         platforms=sorted(e.platform for e in env_list),
         sources=[""],  # Empty source as before
         time_metadata=CondaLockV1TimeMetadata(created_at=timestamp),
-        custom_metadata=CondaLockV1CustomMetadata(
-            created_by=f"conda-lockfiles {__version__}"
-        ),
+        custom_metadata=custom_metadata,
     )
 
     # Construct and return CondaLockV1 instance
     return CondaLockV1(version=1, metadata=metadata, package=packages)
+
+
+def _requested_packages_from_metadata(
+    metadata: CondaLockV1Metadata,
+    explicit_package_names: set[str],
+) -> list[MatchSpec]:
+    """Decode requested specs from ``metadata.custom_metadata``.
+
+    Returns an empty list when the key is absent or unparseable. Specs
+    whose package name is not in ``explicit_package_names`` are dropped
+    with a warning; ``Environment.__post_init__`` would otherwise reject
+    the whole object.
+    """
+    if not metadata.custom_metadata:
+        return []
+    raw = metadata.custom_metadata.get(REQUESTED_SPECS_KEY)
+    if not raw:
+        return []
+    try:
+        spec_strings = json.loads(raw)
+    except (TypeError, ValueError):
+        warnings.warn(
+            f"{REQUESTED_SPECS_KEY!r} in lockfile custom_metadata is not "
+            "valid JSON; dropping requested_packages.",
+            stacklevel=2,
+        )
+        return []
+    if not isinstance(spec_strings, list):
+        return []
+    specs: list[MatchSpec] = []
+    for s in spec_strings:
+        if not isinstance(s, str):
+            continue
+        try:
+            ms = MatchSpec(s)
+        except Exception:
+            continue
+        if ms.name in explicit_package_names:
+            specs.append(ms)
+    return specs
 
 
 def conda_lock_v1_to_conda_env(
@@ -283,14 +339,19 @@ def conda_lock_v1_to_conda_env(
                 raise ValueError(f"Unknown package type: {pkg.manager}")
             external_packages.setdefault(key, []).append(pkg.url)
 
+    resolved_explicit = records_from_conda_urls(
+        explicit_packages, dry_run=context.dry_run
+    )
     return Environment(
         prefix=context.target_prefix,
         platform=platform,
         config=config,
-        explicit_packages=records_from_conda_urls(
-            explicit_packages, dry_run=context.dry_run
-        ),
+        explicit_packages=resolved_explicit,
         external_packages=external_packages,
+        requested_packages=_requested_packages_from_metadata(
+            lockfile.metadata,
+            {pkg.name for pkg in resolved_explicit},
+        ),
     )
 
 

--- a/conda_lockfiles/history.py
+++ b/conda_lockfiles/history.py
@@ -1,0 +1,39 @@
+"""Read user-requested specs from a conda prefix via conda-meta/history.
+
+Upstream ``conda.models.environment.Environment.from_prefix()`` defaults to
+``from_history=False``, which populates ``Environment.requested_packages``
+with a ``MatchSpec`` for *every* installed ``PrefixRecord`` rather than
+user intent. ``conda export`` likewise only passes ``from_history=True``
+when the user supplies ``--from-history`` on the CLI.
+
+Our exporters want actual user intent regardless of that CLI flag, so we
+re-derive from ``conda-meta/history`` ourselves. Tracked upstream at
+https://github.com/conda/conda/issues/15961.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from conda.history import History
+
+if TYPE_CHECKING:
+    from conda.common.path import PathType
+
+
+def requested_specs_from_prefix(prefix: PathType | None) -> list[str]:
+    """Return user-requested specs recorded in ``prefix``'s history.
+
+    Returns an empty list when ``prefix`` is falsy, does not exist, or has
+    no ``conda-meta/history`` file. Specs are returned as canonical
+    ``MatchSpec`` string form (``str(MatchSpec)``), sorted by package name
+    for stable output.
+    """
+    if not prefix:
+        return []
+    prefix_path = Path(prefix)
+    if not (prefix_path / "conda-meta" / "history").is_file():
+        return []
+    specs_map = History(str(prefix_path)).get_requested_specs_map()
+    return sorted(str(spec) for spec in specs_map.values())

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -9,12 +9,14 @@ from conda.common.serialize import yaml_safe_dump
 from conda.exceptions import CondaValueError
 from conda.models.channel import Channel
 from conda.models.environment import Environment, EnvironmentConfig
+from conda.models.match_spec import MatchSpec
 from conda.plugins.types import EnvironmentSpecBase
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from ruamel.yaml import YAMLError
 from ruamel.yaml.parser import ParserError
 
 from ..exceptions import CondaLockfilesParserError, CondaLockfilesValidationError
+from ..history import requested_specs_from_prefix
 from ..load_yaml import load_yaml
 from ..records_from_conda_urls import records_from_conda_urls
 from ..validate_urls import validate_urls
@@ -112,11 +114,29 @@ class RattlerLockV6Package(RattlerLockV6PackageReference):
 class RattlerLockV6Environment(BaseModel):
     """An environment specification in a rattler lock file."""
 
+    model_config = {"populate_by_name": True}
+
     channels: list[RattlerLockV6Channel]
     packages: Annotated[
         dict[str, list[RattlerLockV6PackageReference]],
         Field(description="Mapping of platforms to package references (package URLs)"),
     ]
+    # Non-standard extension: user-requested MatchSpec strings keyed by
+    # platform. Serialized as ``requested-packages`` to match rattler's
+    # kebab-case convention for multi-word keys. rattler silently ignores
+    # unknown fields on read, but WILL drop them on any re-serialize
+    # (``pixi add``, ``pixi update``, ...), so treat this as advisory.
+    requested_packages: Annotated[
+        dict[str, list[str]] | None,
+        Field(
+            default=None,
+            alias="requested-packages",
+            description=(
+                "User-requested MatchSpec strings, keyed by platform. "
+                "Non-standard extension; dropped on rattler re-serialize."
+            ),
+        ),
+    ] = None
 
 
 class RattlerLockV6(BaseModel):
@@ -226,8 +246,22 @@ def rattler_lock_v6_from_conda_envs(envs: Iterable[Environment]) -> RattlerLockV
     env = env_list[0]
     channels = [RattlerLockV6Channel(url=channel) for channel in env.config.channels]
 
+    # Record user intent per-platform from each prefix's history. We
+    # re-derive rather than trusting env.requested_packages because conda
+    # fills that with the full install list by default
+    # (conda/conda#15961).
+    requested_packages: dict[str, list[str]] = {}
+    for e in env_list:
+        specs = requested_specs_from_prefix(e.prefix)
+        if specs:
+            requested_packages[e.platform] = specs
+
     # Build environment
-    default_env = RattlerLockV6Environment(channels=channels, packages=platforms)
+    default_env = RattlerLockV6Environment(
+        channels=channels,
+        packages=platforms,
+        requested_packages=requested_packages or None,
+    )
 
     # Construct and return RattlerLockV6 instance
     return RattlerLockV6(
@@ -279,14 +313,34 @@ def rattler_lock_v6_to_conda_env(
                 raise ValueError(f"Unknown package type: {ref.package_type}")
             external_packages.setdefault(key, []).append(ref.url)
 
+    resolved_explicit = records_from_conda_urls(
+        explicit_packages, dry_run=context.dry_run
+    )
+
+    # Decode per-platform user-requested specs. Drop specs whose name
+    # isn't in the platform's explicit packages: Environment.__post_init__
+    # enforces requested_packages ⊆ explicit_packages by name.
+    requested_packages: list[MatchSpec] = []
+    if environment.requested_packages:
+        platform_specs = environment.requested_packages.get(platform, [])
+        explicit_names = {pkg.name for pkg in resolved_explicit}
+        for spec_str in platform_specs:
+            if not isinstance(spec_str, str):
+                continue
+            try:
+                ms = MatchSpec(spec_str)
+            except Exception:
+                continue
+            if ms.name in explicit_names:
+                requested_packages.append(ms)
+
     return Environment(
         prefix=context.target_prefix,
         platform=platform,
         config=config,
-        explicit_packages=records_from_conda_urls(
-            explicit_packages, dry_run=context.dry_run
-        ),
+        explicit_packages=resolved_explicit,
         external_packages=external_packages,
+        requested_packages=requested_packages,
     )
 
 
@@ -298,6 +352,7 @@ def multiplatform_export(envs: Iterable[Environment]) -> str:
             lockfile.model_dump(
                 exclude_none=True,
                 mode="python",
+                by_alias=True,
             )
         )
     except YAMLError as e:

--- a/tests/data/environments/single_package/conda-lock.yml
+++ b/tests/data/environments/single_package/conda-lock.yml
@@ -12,6 +12,7 @@ metadata:
     created_at: '2025-08-14T22:47:07Z'
   custom_metadata:
     created_by: conda-lockfiles 0.0.0
+    requested_specs: '["python_abi"]'
 package:
   - name: python_abi
     version: '3.13'

--- a/tests/data/environments/single_package/pixi.lock
+++ b/tests/data/environments/single_package/pixi.lock
@@ -6,6 +6,9 @@ environments:
     packages:
       linux-64:
         - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-7_cp313.conda
+    requested-packages:
+      linux-64:
+        - python_abi
 packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-7_cp313.conda
     sha256: 0595134584589064f56e67d3de1d8fcbb673a972946bce25fb593fb092fdcd97

--- a/tests/test_requested_specs.py
+++ b/tests/test_requested_specs.py
@@ -1,0 +1,96 @@
+"""Round-trip tests for user-requested specs in exported lockfiles.
+
+Covers issue #8: exports include specs from the prefix's
+``conda-meta/history``, and loaders populate ``Environment.requested_packages``
+from that data.
+"""
+
+from __future__ import annotations
+
+import json
+
+from conda_lockfiles.conda_lock.v1 import (
+    CONDA_LOCK_FILE,
+    REQUESTED_SPECS_KEY,
+    CondaLockV1Loader,
+)
+from conda_lockfiles.history import requested_specs_from_prefix
+from conda_lockfiles.load_yaml import load_yaml
+from conda_lockfiles.rattler_lock.v6 import PIXI_LOCK_FILE, RattlerLockV6Loader
+
+from . import SINGLE_PACKAGE_ENV
+
+
+def test_requested_specs_from_prefix_reads_history() -> None:
+    """``requested_specs_from_prefix`` returns history-recorded specs."""
+    specs = requested_specs_from_prefix(SINGLE_PACKAGE_ENV)
+    assert specs == ["python_abi"]
+
+
+def test_requested_specs_from_prefix_missing_prefix(tmp_path) -> None:
+    """Missing prefix or missing history file returns an empty list."""
+    assert requested_specs_from_prefix(None) == []
+    assert requested_specs_from_prefix(tmp_path / "does-not-exist") == []
+    assert requested_specs_from_prefix(tmp_path) == []  # exists, no history
+
+
+def test_conda_lock_v1_fixture_contains_requested_specs() -> None:
+    """Our reference fixture carries the spec string in custom_metadata."""
+    data = load_yaml(SINGLE_PACKAGE_ENV / CONDA_LOCK_FILE)
+    payload = data["metadata"]["custom_metadata"][REQUESTED_SPECS_KEY]
+    assert json.loads(payload) == ["python_abi"]
+
+
+def test_conda_lock_v1_loader_populates_requested_packages() -> None:
+    """Loader decodes custom_metadata and yields a MatchSpec on the Environment."""
+    loader = CondaLockV1Loader(SINGLE_PACKAGE_ENV / CONDA_LOCK_FILE)
+    env = loader.env_for("linux-64")
+    assert [str(ms) for ms in env.requested_packages] == ["python_abi"]
+
+
+def test_rattler_lock_v6_fixture_contains_requested_packages() -> None:
+    """Our reference fixture carries the per-platform spec list."""
+    data = load_yaml(SINGLE_PACKAGE_ENV / PIXI_LOCK_FILE)
+    env_block = data["environments"]["default"]
+    assert env_block["requested-packages"] == {"linux-64": ["python_abi"]}
+
+
+def test_rattler_lock_v6_loader_populates_requested_packages() -> None:
+    loader = RattlerLockV6Loader(SINGLE_PACKAGE_ENV / PIXI_LOCK_FILE)
+    env = loader.env_for("linux-64")
+    assert [str(ms) for ms in env.requested_packages] == ["python_abi"]
+
+
+def test_conda_lock_v1_loader_tolerates_invalid_requested_specs(tmp_path) -> None:
+    """An unparseable ``requested_specs`` payload is dropped, not raised."""
+    # Minimal lockfile with a malformed requested_specs value.
+    lockfile = tmp_path / CONDA_LOCK_FILE
+    url = "https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-7_cp313.conda"
+    sha = "0595134584589064f56e67d3de1d8fcbb673a972946bce25fb593fb092fdcd97"
+    lockfile.write_text(
+        "version: 1\n"
+        "metadata:\n"
+        "  content_hash: {}\n"
+        "  channels:\n"
+        "    - url: conda-forge\n"
+        "      used_env_vars: []\n"
+        "  platforms: [linux-64]\n"
+        "  sources: ['']\n"
+        "  custom_metadata:\n"
+        "    requested_specs: 'not-json'\n"
+        "package:\n"
+        "  - name: python_abi\n"
+        "    version: '3.13'\n"
+        "    manager: conda\n"
+        "    platform: linux-64\n"
+        "    dependencies: {}\n"
+        f"    url: {url}\n"
+        "    hash:\n"
+        "      md5: e84b44e6300f1703cb25d29120c5b1d8\n"
+        f"      sha256: {sha}\n"
+        "    category: main\n"
+        "    optional: false\n"
+    )
+    loader = CondaLockV1Loader(lockfile)
+    env = loader.env_for("linux-64")
+    assert env.requested_packages == []


### PR DESCRIPTION
Closes #8.

## Summary

Populates user-requested specs into both supported lockfile formats so exports/round-trips carry "what the user asked for", not just the full explicit install set.

Intent is sourced from `conda-meta/history` via a new `conda_lockfiles.history.requested_specs_from_prefix` helper. We re-derive from history rather than trust `env.requested_packages` because conda populates that field with every installed package by default (`Environment.from_prefix(from_history=False)`, tracked upstream at conda/conda#15961).

## Storage

**conda-lock-v1** — `metadata.custom_metadata.requested_specs`, JSON-encoded list of MatchSpec strings:

```yaml
metadata:
  custom_metadata:
    created_by: conda-lockfiles 0.1.x
    requested_specs: '["python_abi"]'
```

- Widens our `custom_metadata` model to free-form `dict[str, str]` to match upstream conda-lock and CEP 37.
- Key name `requested_specs` follows CEP 32's terminology for MatchSpec-string lists; no namespacing since conda-lock has no convention and no CEP mandates it.
- Low interop risk: conda-lock's `LockMeta` is `StrictModel` (extra fields rejected), but `custom_metadata` itself is explicitly a user-extensible `dict[str, str]`.

**rattler-lock-v6** — `environments.<name>.requested-packages` as a per-platform map:

```yaml
environments:
  default:
    channels:
      - url: conda-forge
    packages:
      linux-64:
        - conda: https://.../python_abi-3.13-7_cp313.conda
    requested-packages:
      linux-64:
        - python_abi
```

- Kebab-case key matches rattler's serialization convention for multi-word fields (`SolveOptions` uses `#[serde(rename_all = "kebab-case")]`).
- rattler's deserializer does NOT use `deny_unknown_fields`, so `pixi install --frozen` keeps working and ignores the extension.
- Caveat: any rattler-driven re-lock (`pixi add`, `pixi update`) will drop the annotation. This is advisory, not durable. Documented inline.

## Loader round-trip

Both `CondaLockV1Loader` and `RattlerLockV6Loader` decode the fields and populate `Environment.requested_packages` as `list[MatchSpec]`. Specs whose package name isn't in the platform's `explicit_packages` are dropped because `Environment.__post_init__` enforces the subset relationship and would otherwise raise.

## Test coverage

New `tests/test_requested_specs.py` with 7 tests covering the history helper, fixture contents, loader population for both formats, and malformed-payload tolerance. The existing `single_package` fixtures (`conda-lock.yml`, `pixi.lock`) are updated to carry the new field, so the existing `test_export_to_conda_lock_v1[single-package]` and `test_export_to_rattler_lock_v6[single-package]` round-trip comparisons now also validate serialization.

Full suite: 55 passed locally on `test-py313`.

## References

- Upstream issue about the `from_history=False` default: conda/conda#15961
- `conda.history.History`: https://github.com/conda/conda/blob/main/conda/history.py
- `Environment.from_prefix`: https://github.com/conda/conda/blob/main/conda/models/environment.py
- CEP 32 (`requested_specs` terminology): https://github.com/conda/ceps/blob/main/cep-0032.md
- CEP 37 (conda-lock v1 `custom_metadata`): https://github.com/conda/ceps/blob/main/cep-0037.md
- conda-lock `LockMeta`: https://github.com/conda/conda-lock/blob/main/conda_lock/lockfile/v1/models.py
- rattler lock deserializer (no `deny_unknown_fields`): https://github.com/conda/rattler/blob/main/crates/rattler_lock/src/parse/deserialize.rs