### PR TITLE
Prepare 0.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 [//]: # (current developments)
 
+## 0.2.1 (2026-07-07)
+
+### Docs
+
+* Remove the early-stage production warning from the README and docs, and update lockfile creation examples to use `conda create` consistently. (#144)
+
+### Tests
+
+* Make round-trip and interop tests create temporary environments with an explicit `conda-forge` channel so release checks do not depend on ambient conda channel configuration. (#153)
+
+### Other
+
+* Configure the standard on-demand release process template, including the `MAJOR.MINOR.PATCH` version placeholder for generated release files. (#149, #150)
+* Simplify the repository update workflow to scheduled/manual runs and refresh synced infrastructure workflow files. (#146, #147)
+* Bump `prefix-dev/setup-pixi` from 0.9.5 to 0.9.6 in the docs and test workflows. (#148)
+
 ## 0.2.0 (2026-05-06)
 
 ### Enhancements

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -37,6 +37,7 @@ pytestmark = pytest.mark.interop
 # avoids flakiness from the solver picking different builds across
 # platforms. zlib is what the existing round-trip tests already use.
 INTEROP_PACKAGE = "zlib"
+CONDA_FORGE_CHANNEL_ARGS = ("--override-channels", "--channel=conda-forge")
 
 
 @pytest.fixture
@@ -90,7 +91,7 @@ def test_external_tool_consumes_our_export(
     lockfile = workdir / filename
 
     # Export a small env via our plugin.
-    with tmp_env(INTEROP_PACKAGE) as prefix:
+    with tmp_env(*CONDA_FORGE_CHANNEL_ARGS, INTEROP_PACKAGE) as prefix:
         out, err, rc = conda_cli(
             "export",
             f"--prefix={prefix}",

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -13,6 +13,8 @@ from conda_lockfiles.rattler_lock import v6 as rattler_lock_v6
 
 from . import compare_conda_lock_v1, compare_rattler_lock_v6
 
+CONDA_FORGE_CHANNEL_ARGS = ("--override-channels", "--channel=conda-forge")
+
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Callable
@@ -52,7 +54,7 @@ def test_export(
     prefix2 = path_factory()
     lockfile2 = path_factory(filename)
 
-    with tmp_env("zlib") as prefix:
+    with tmp_env(*CONDA_FORGE_CHANNEL_ARGS, "zlib") as prefix:
         # export environment to a lockfile
         out, err, rc = conda_cli(
             "export",
@@ -96,7 +98,7 @@ def test_conda_lock_v1_export_detects_yaml_extension(
 ) -> None:
     """conda-lock-v1 must be inferred from conda-lock.yaml (CEP-37 / issue #121)."""
     lockfile = path_factory("conda-lock.yaml")
-    with tmp_env("zlib") as prefix:
+    with tmp_env(*CONDA_FORGE_CHANNEL_ARGS, "zlib") as prefix:
         out, err, rc = conda_cli(
             "export",
             f"--prefix={prefix}",
@@ -138,7 +140,7 @@ def test_multiplatform_export(
 ):
     platforms = tuple(sorted({context.subdir, "linux-64", "osx-arm64", "win-64"}))
     lockfile = path_factory(filename)
-    with tmp_env("zlib") as prefix:
+    with tmp_env(*CONDA_FORGE_CHANNEL_ARGS, "zlib") as prefix:
         # export environment to a lockfile
         out, err, rc = conda_cli(
             "export",


### PR DESCRIPTION
### Description

Prepare the 0.2.1 release from current `main` by adding unreleased changelog notes for the post-0.2.0 changes and making release-check tests independent of ambient conda channel configuration.

The test change is needed because local release checks can otherwise fail with `NoChannelsConfiguredError` when the user environment has no configured channels. The tests now pass explicit `conda-forge` channel arguments when creating their temporary `zlib` environments.

Refs #153.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release notes? Not needed; this PR updates `CHANGELOG.md` for the 0.2.1 release.
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? Not needed beyond the changelog update.