### PR TITLE
Fix conda-pypi wheel loader overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Remove the early-stage production warning from the README and docs, and update lockfile creation examples to use `conda create` consistently. (#144)
 
+### Bug fixes
+
+* Preserve conda-pypi wheel package channel, checksum, and subdir metadata when loading conda-lock v1 and rattler-lock v6 lockfiles. (#152)
+
 ### Tests
 
 * Make round-trip and interop tests create temporary environments with an explicit `conda-forge` channel so release checks do not depend on ambient conda channel configuration. (#153)

--- a/conda_lockfiles/__init__.py
+++ b/conda_lockfiles/__init__.py
@@ -12,6 +12,12 @@ if TYPE_CHECKING:
 #: Application name.
 APP_NAME: Final = "conda-lockfiles"
 
+#: Channel name used for conda-pypi wheel package records.
+CONDA_PYPI_CHANNEL_NAME: Final = "conda-pypi"
+
+#: URL prefix used by PyPI-hosted wheel artifacts in conda-pypi records.
+PYTHONHOSTED_URL_PREFIX: Final = "https://files.pythonhosted.org/"
+
 try:
     from ._version import __version__
 except ImportError:

--- a/conda_lockfiles/conda_lock/v1.py
+++ b/conda_lockfiles/conda_lock/v1.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, ValidationError
 from ruamel.yaml import YAMLError
 from ruamel.yaml.parser import ParserError
 
-from .. import __version__
+from .. import CONDA_PYPI_CHANNEL_NAME, PYTHONHOSTED_URL_PREFIX, __version__
 from ..exceptions import CondaLockfilesParserError, CondaLockfilesValidationError
 from ..load_yaml import load_yaml
 from ..records_from_conda_urls import records_from_conda_urls
@@ -160,28 +160,6 @@ def _record_to_package(
     )
 
 
-def _package_to_record_overrides(pkg: CondaLockV1Package) -> dict[str, Any]:
-    """
-    Convert CondaLockV1Package to record overrides dict.
-
-    :param pkg: Package from lockfile
-    :return: Dict of overrides for records_from_conda_urls
-    """
-    if pkg.manager != "conda":
-        raise ValueError(f"Unsupported manager: {pkg.manager}")
-
-    return {
-        # dependencies are converted to a list of strings
-        "depends": [f"{name} {version}" for name, version in pkg.dependencies.items()],
-        # platform is renamed to subdir
-        "subdir": pkg.platform,
-        # pass through other fields
-        "name": pkg.name,
-        "version": pkg.version,
-        "hash": pkg.hash.model_dump(exclude_none=True),
-    }
-
-
 def conda_lock_v1_from_conda_envs(envs: Iterable[Environment]) -> CondaLockV1:
     """
     Create a CondaLockV1 lockfile from conda Environment objects.
@@ -263,6 +241,14 @@ def conda_lock_v1_to_conda_env(
     # Map conda-lock v1 packages to conda/external package records
     explicit_packages: dict[str, dict[str, Any]] = {}
     external_packages: dict[str, list[str]] = {}
+    conda_pypi_channel = next(
+        (
+            channel.url
+            for channel in lockfile.metadata.channels
+            if Channel(channel.url).canonical_name == CONDA_PYPI_CHANNEL_NAME
+        ),
+        None,
+    )
     for pkg in lockfile.package:
         # Filter packages
         if pkg.platform != platform:
@@ -276,7 +262,17 @@ def conda_lock_v1_to_conda_env(
 
         # Group by manager
         if pkg.manager == "conda":
-            explicit_packages[pkg.url] = _package_to_record_overrides(pkg)
+            overrides = {
+                "depends": [
+                    f"{name} {version}" for name, version in pkg.dependencies.items()
+                ],
+                "name": pkg.name,
+                "version": pkg.version,
+                **pkg.hash.model_dump(exclude_none=True),
+            }
+            if conda_pypi_channel and pkg.url.startswith(PYTHONHOSTED_URL_PREFIX):
+                overrides["channel"] = conda_pypi_channel
+            explicit_packages[pkg.url] = overrides
         else:
             # Map conda-lock v1 package type to conda package type
             try:

--- a/conda_lockfiles/rattler_lock/v6.py
+++ b/conda_lockfiles/rattler_lock/v6.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 from ruamel.yaml import YAMLError
 from ruamel.yaml.parser import ParserError
 
+from .. import CONDA_PYPI_CHANNEL_NAME, PYTHONHOSTED_URL_PREFIX
 from ..exceptions import CondaLockfilesParserError, CondaLockfilesValidationError
 from ..load_yaml import load_yaml
 from ..records_from_conda_urls import records_from_conda_urls
@@ -269,12 +270,25 @@ def rattler_lock_v6_to_conda_env(
     # Map rattler v6 packages to conda/external package records
     explicit_packages: dict[str, dict[str, Any]] = {}
     external_packages: dict[str, list[str]] = {}
+    conda_pypi_channel = next(
+        (
+            channel.url
+            for channel in channels
+            if Channel(channel.url).canonical_name == CONDA_PYPI_CHANNEL_NAME
+        ),
+        None,
+    )
     for ref in environment.packages.get(platform, ()):
         # Group by manager
         if ref.conda:
-            explicit_packages[ref.url] = next(
-                pkg for pkg in lockfile.packages if pkg.url == ref.url
-            ).model_dump()
+            pkg = next(pkg for pkg in lockfile.packages if pkg.url == ref.url)
+            overrides = pkg.model_dump(
+                exclude={"conda", "pypi"},
+                exclude_none=True,
+            )
+            if conda_pypi_channel and ref.url.startswith(PYTHONHOSTED_URL_PREFIX):
+                overrides["channel"] = conda_pypi_channel
+            explicit_packages[ref.url] = overrides
         else:
             # Map rattler v6 package type to conda package type
             try:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -8,6 +8,7 @@ from conda.plugins.types import EnvironmentFormat
 
 if TYPE_CHECKING:
     from conda.plugins.manager import CondaPluginManager
+    from pytest_mock import MockerFixture
 
 from conda_lockfiles.conda_lock import v1 as conda_lock_v1
 from conda_lockfiles.rattler_lock import v6 as rattler_lock_v6
@@ -34,6 +35,14 @@ CONDA_LOCK_METADATA_MD5 = {
     "osx-arm64": "cda0ec640bc4698d0813a8fb459aee58",
     "win-64": "92b11b0b2120d563caa1629928122cee",
 }
+
+PYTHONHOSTED_WHEEL_URL = (
+    "https://files.pythonhosted.org/packages/ab/cd/langfuse-4.6.1-py3-none-any.whl"
+)
+PYTHONHOSTED_WHEEL_MD5 = "0123456789abcdef0123456789abcdef"
+PYTHONHOSTED_WHEEL_SHA256 = (
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
 
 
 @pytest.mark.parametrize(
@@ -240,3 +249,107 @@ def test_env_unchanged(loader) -> None:
     env = loader.env
     assert env.platform == context.subdir
     assert env.explicit_packages
+
+
+@pytest.mark.parametrize(
+    "module,lockfile,load_env,expected_overrides",
+    [
+        pytest.param(
+            conda_lock_v1,
+            conda_lock_v1.CondaLockV1(
+                metadata=conda_lock_v1.CondaLockV1Metadata(
+                    channels=[
+                        conda_lock_v1.CondaLockV1Channel(url="main"),
+                        conda_lock_v1.CondaLockV1Channel(url="conda-pypi"),
+                    ],
+                    platforms=["osx-arm64"],
+                ),
+                package=[
+                    conda_lock_v1.CondaLockV1Package(
+                        name="langfuse",
+                        version="4.6.1",
+                        manager="conda",
+                        platform="osx-arm64",
+                        dependencies={"protobuf": ">=6"},
+                        url=PYTHONHOSTED_WHEEL_URL,
+                        hash=conda_lock_v1.CondaLockV1Hash(
+                            md5=PYTHONHOSTED_WHEEL_MD5,
+                            sha256=PYTHONHOSTED_WHEEL_SHA256,
+                        ),
+                    )
+                ],
+            ),
+            conda_lock_v1.conda_lock_v1_to_conda_env,
+            {
+                "channel": "conda-pypi",
+                "depends": ["protobuf >=6"],
+                "md5": PYTHONHOSTED_WHEEL_MD5,
+                "name": "langfuse",
+                "sha256": PYTHONHOSTED_WHEEL_SHA256,
+                "version": "4.6.1",
+            },
+            id="conda-lock-v1",
+        ),
+        pytest.param(
+            rattler_lock_v6,
+            rattler_lock_v6.RattlerLockV6(
+                environments={
+                    "default": rattler_lock_v6.RattlerLockV6Environment(
+                        channels=[
+                            rattler_lock_v6.RattlerLockV6Channel(url="main"),
+                            rattler_lock_v6.RattlerLockV6Channel(url="conda-pypi"),
+                        ],
+                        packages={
+                            "osx-arm64": [
+                                rattler_lock_v6.RattlerLockV6PackageReference(
+                                    conda=PYTHONHOSTED_WHEEL_URL,
+                                )
+                            ]
+                        },
+                    )
+                },
+                packages=[
+                    rattler_lock_v6.RattlerLockV6Package(
+                        conda=PYTHONHOSTED_WHEEL_URL,
+                        md5=PYTHONHOSTED_WHEEL_MD5,
+                        sha256=PYTHONHOSTED_WHEEL_SHA256,
+                        depends=["python >=3.14"],
+                        license="MIT",
+                    )
+                ],
+            ),
+            rattler_lock_v6.rattler_lock_v6_to_conda_env,
+            {
+                "channel": "conda-pypi",
+                "depends": ["python >=3.14"],
+                "license": "MIT",
+                "md5": PYTHONHOSTED_WHEEL_MD5,
+                "sha256": PYTHONHOSTED_WHEEL_SHA256,
+            },
+            id="rattler-lock-v6",
+        ),
+    ],
+)
+def test_conda_pypi_record_overrides(
+    module,
+    lockfile,
+    load_env,
+    expected_overrides,
+    mocker: MockerFixture,
+) -> None:
+    """Loaders preserve conda-pypi wheel metadata for explicit package records."""
+    captured_metadata = {}
+
+    def capture_records(metadata_by_url, **kwargs):
+        captured_metadata.update(metadata_by_url)
+        return ()
+
+    mocker.patch.object(
+        module,
+        "records_from_conda_urls",
+        side_effect=capture_records,
+    )
+
+    load_env(lockfile, platform="osx-arm64")
+
+    assert captured_metadata[PYTHONHOSTED_WHEEL_URL] == expected_overrides


### PR DESCRIPTION
### Description

Fixes conda-pypi wheel package metadata restoration when loading conda-lock v1 and rattler-lock v6 lockfiles.

The conda-lock v1 loader no longer forces the selected host platform into package record overrides and now passes lockfile checksums as top-level `md5` / `sha256` fields so fetch verification can use them. Both loaders now infer the `conda-pypi` channel for `files.pythonhosted.org` wheel URLs when that channel is present in the lockfile context, so install plans no longer fall back to an unknown channel for those records.

The rattler-lock v6 loader also stops passing lockfile URL selector keys such as `conda` and `pypi` into package record overrides, keeping only valid record metadata.

Fixes #152.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes? Not needed; this updates `CHANGELOG.md` for 0.2.1.
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? Not needed beyond the changelog update.
