### PR TITLE
Update 0.2.1 changelog PR reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-* Preserve conda-pypi wheel package channel, checksum, and subdir metadata when loading conda-lock v1 and rattler-lock v6 lockfiles. (#152)
+* Preserve conda-pypi wheel package channel, checksum, and subdir metadata when loading conda-lock v1 and rattler-lock v6 lockfiles. (#156)
 
 ### Tests
 


### PR DESCRIPTION
### Description

Update the 0.2.1 changelog bugfix entry to cite merged PR #156 instead of issue #152, so the release notes point at the PR that landed the conda-pypi loader fix.

Refs #153.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-lockfiles/blob/main/news/TEMPLATE)) for the next release's release notes? Not needed; this corrects the 0.2.1 changelog entry itself.
- [x] Add / update necessary tests? Not needed; changelog-only correction.
- [x] Add / update outdated documentation? Updated `CHANGELOG.md`.
